### PR TITLE
Update Cypher queries documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -151,7 +151,7 @@ this inflates py2neo nodes to neomodel node objects::
 
     class Person(StructuredNode):
         def friends(self):
-            results = self.cypher("START a=node({self}) MATCH a-[:FRIEND]->(b) RETURN b");
+            results, metadata = self.cypher("START a=node({self}) MATCH a-[:FRIEND]->(b) RETURN b");
             return [self.__class__.inflate(row[0]) for row in results]
 
 The self query parameter is prepopulated with the current node id. It's possible to pass in your


### PR DESCRIPTION
cypher() returns the tuple (results,metadata), so in the given example, result is not a list of nodes as expected. Rather, results[0] would contain the list of nodes, and results[1] would contain the metadata.
