### PR TITLE
Fixed a couple of validator decorator issues

### DIFF
--- a/neomodel/properties.py
+++ b/neomodel/properties.py
@@ -12,12 +12,12 @@ if sys.version_info >= (3, 0):
 
 def validator(fn):
     fn_name = fn.func_name if hasattr(fn, 'func_name') else fn.__name__
-    if fn_name is 'inflate':
+    if fn_name == 'inflate':
         exc_class = InflateError
     elif fn_name == 'deflate':
         exc_class = DeflateError
     else:
-        raise Exception("Unknown Property method " + fn.func_name)
+        raise Exception("Unknown Property method " + fn_name)
 
     @functools.wraps(fn)
     def validator(self, value, node_id=None):


### PR DESCRIPTION
This patch fixes a few issues with the validator decorator. The first being the use of the `is` operator to compare strings, which was resulting in a comparison that always failed (on my system). This problem is not evident always, as different systems have different string object caching length limits. Anyway, an example:

```
>>> a = "foo"
>>> b = "foo"
>>> a is b
True
>>> a == b
True
>>> a = " " * 100
>>> b = " " * 100
>>> a is b
False
>>> a == b
True
```

See [this stackoverflow question for more](http://stackoverflow.com/questions/2988017/string-comparison-in-python-is-vs).

The second issue is what I assume is just a typo; in line 19, the code was using `fn.func_name`, where previously it had defined the `fn_name` which takes into acount the fact that Python3.x function objects do not have a `func_name` attribute.

The third change is almost stylistic, but I used the `functool.wraps` decorator on the inner wrapping function. This change means that the wrapped function will retain it's name, argument list, and other characteristics. While not affecting how the code runs, it does make the decorator "transparent".

I have only tested these changes on Python 3.3.2, but I belive they will work on most all modern version of Python
