### PR TITLE
fixed header value

### DIFF
--- a/neomodel/util.py
+++ b/neomodel/util.py
@@ -19,7 +19,7 @@ class CustomBatch(neo4j.WriteBatch):
         rs = self._graph_db._send(rest.Request(self._graph_db, "POST", self._graph_db._batch_uri, [
             request.description(id_)
             for id_, request in enumerate(self.requests)
-        ], {'X-Stream': True}))
+        ], {'X-Stream': 'true;format=pretty'}))
         self.clear()
         return [
             rest.Response(


### PR DESCRIPTION
Following a recent py2neo+neomodel bug report, I've identified an incorrect type used for the `X-Stream` header value. Changed from `bool` to `str`.
