### PR TITLE
bug fix for shared index after 3+ level hierarchy

### DIFF
--- a/neomodel/core.py
+++ b/neomodel/core.py
@@ -75,8 +75,8 @@ class StructuredNodeMeta(type):
                     # support for 'magic' properties
                     if hasattr(value, 'setup') and hasattr(value.setup, '__call__'):
                         value.setup()
-            if '__index__' in dct:
-                name = dct['__index__']
+            if '__index__' in dct or hasattr(inst, '__index__'):
+                name = dct['__index__'] if '__index__' in dct else getattr(inst, '__index__')
             inst.index = NodeIndexManager(inst, name)
         return inst
 


### PR DESCRIPTION
Hi, I got one bug while sharing indexes after 3rd level of hierarchy, so i debugged and found one solution for my problem, but not sure if this the cause, please check the patch.

In the following case, the shared index hierarchy will fail to use the index in the neo4j, when saving any instance of **C** creating the **C** index when not necessary.

``` python
class A(SemiStructedNode)
  __index__ = 'CustomIndex'
class B(A)
  pass
class C(B)
  pass
```
