### PR TITLE
Fixed bug when using strftime with %s params, because it converts an utc...

### DIFF
--- a/neomodel/properties.py
+++ b/neomodel/properties.py
@@ -198,15 +198,19 @@ class DateTimeProperty(Property):
 
     @validator
     def deflate(self, value):
+        #: Fixed timestamp strftime following suggestion from
+        # http://stackoverflow.com/questions/11743019/convert-python-datetime-to-epoch-with-strftime
         if not isinstance(value, datetime):
             raise ValueError('datetime object expected, got {0}'.format(value))
         if value.tzinfo:
             value = value.astimezone(pytz.utc)
+            epoch_date = datetime(1970,1,1,tzinfo=pytz.utc)
         elif os.environ.get('NEOMODEL_FORCE_TIMEZONE', False):
             raise ValueError("Error deflating {} no timezone provided".format(value))
         else:
             logger.warning("No timezone sepecified on datetime object.. will be inflated to UTC")
-        return float(value.strftime('%s.%f'))
+            epoch_date = datetime(1970,1,1)
+        return float((value - epoch_date).total_seconds())
 
 
 class JSONProperty(Property):


### PR DESCRIPTION
Hi, this fixes a behaviour were neomodel continues saving wrong dates when local computer timezones differ from UTC.

With help from @arhuaco !
