### PR TITLE
Issue #112: do not duplicate labels in cypher query if equal

### DIFF
--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -243,8 +243,14 @@ class QueryBuilder(object):
         traverse a relationship from a node to a set of nodes
         """
         # build source
-        lhs_ident = self.build_source(traversal.source) + ':' + traversal.source_class.__label__
-        rhs_ident = traversal.name + ':' + traversal.target_class.__label__
+        lhs_label = ':' + traversal.source_class.__label__
+        rhs_label = ':' + traversal.target_class.__label__
+        if lhs_label == rhs_label:
+            lhs_label = ''
+
+        # build source
+        lhs_ident = self.build_source(traversal.source) + lhs_label
+        rhs_ident = traversal.name + rhs_label
         self._ast['return'] = traversal.name
         self._ast['result_class'] = traversal.target_class
 

--- a/test/test_issue112.py
+++ b/test/test_issue112.py
@@ -1,0 +1,20 @@
+from neomodel import StructuredNode, RelationshipTo
+
+
+class TestModel(StructuredNode):
+    test = RelationshipTo('TestModel', 'SELF')
+
+
+def test_len_relationship():
+    t1 = TestModel().save()
+    t2 = TestModel().save()
+
+    t1.test.connect(t2)
+    l = len(t1.test.all())
+
+    assert l
+    assert l == 1
+
+
+if __name__ == '__main__':
+    test_len_relationship()


### PR DESCRIPTION
As requested, the commit in this Pull Request contains the fix and a testcase for issue #112. 

Commit message:
In models that have a Relationship\* to themselves the previous code
added the same label twice in the MATCH clause, for example when
checking the length of a connection.

With this commit the QueryBuilder checks if the labels in the query are
equal and - if yes - leaves out the left hand side label.
