### PR TITLE
Fix for #114

### DIFF
--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -260,13 +260,10 @@ class QueryBuilder(object):
         traverse a relationship from a node to a set of nodes
         """
         # build source
-        lhs_label = ':' + traversal.source_class.__label__
         rhs_label = ':' + traversal.target_class.__label__
-        if lhs_label == rhs_label:
-            lhs_label = ''
 
         # build source
-        lhs_ident = self.build_source(traversal.source) + lhs_label
+        lhs_ident = self.build_source(traversal.source)
         rhs_ident = traversal.name + rhs_label
         self._ast['return'] = traversal.name
         self._ast['result_class'] = traversal.target_class


### PR DESCRIPTION
Fixes issue #114.

Using neo4j 2.1.2, test results BEFORE change

```
Ran 72 tests in 4.917s

FAILED (failures=1, errors=11, skipped=1)
```

AFTER change,

```
Ran 72 tests in 5.129s

FAILED (failures=1, skipped=1)
```
