### PR TITLE
Add possibility to pass transaction object to cypher_query

### DIFF
--- a/neomodel/util.py
+++ b/neomodel/util.py
@@ -84,11 +84,13 @@ class Database(local):
         self._active_transaction = None
 
     @ensure_connection
-    def cypher_query(self, query, params=None, handle_unique=True, retry_on_session_expire=False):
+    def cypher_query(self, query, params=None, handle_unique=True, retry_on_session_expire=True, tx=None):
         if self._pid != os.getpid():
             self.set_connection(self.url)
 
-        if self._active_transaction:
+        if tx is not None:
+            session = tx
+        elif self._active_transaction:
             session = self._active_transaction
         else:
             session = self.driver.session()


### PR DESCRIPTION
This allows for creating a wrapper to be pass a
transaction object created by session.read_transaction()
or session_write_transaction() to a wrapper function and
use this object instead of a TransactionProxy object.

Eg.
```
    def db_cypher_query_wrapper(tx, db, query, params=None, **kwargs):
        """Wrap db.cypher_query taking into account transaction type"""

        # The need to set an internal transaction in db
        # is that db.cypher_query returns more than a statementresult.
        return db.cypher_query(query, params, tx=tx, **kwargs)

       with db.driver.session() as session:
           if query_type == 'read':
              return session.read_transaction(db_cypher_query_wrapper, db, query, params=params, **kwargs)
           elif query_type == 'write':
               return session.write_transaction(db_cypher_query_wrapper, db, query, params=params, **kwargs)
           else:
                raise ValueError('Unknown query type. Must be "read" or "write"')

```