### PR TITLE
Initial work on issue 283 - "Inheritance Breaks"

### DIFF
--- a/doc/source/batch.rst
+++ b/doc/source/batch.rst
@@ -7,7 +7,8 @@ All batch operations can be executed with one or more nodes.
 create()
 --------
 Note that batch create is a relic of the Neo4j REST API.
-Now neomodel uses Bolt it exists for convenience and compatibility and a CREATE query is issued for each dict provided.
+With the adoption of Bolt by neomodel, it exists for convenience and compatibility 
+and a CREATE query is issued for each `dict` provided.
 
 Create multiple nodes at once in a single transaction::
 
@@ -35,10 +36,10 @@ Atomically create or update nodes in a single operation::
         {'name': 'Jane', 'age': 24},
     )
 
-This is useful for ensuring data is up to date, each node is matched by its' required and/or unique properties. Any
+This is useful for ensuring data is up to date, each node is matched by its required and/or unique properties. Any
 additional properties will be set on a newly created or an existing node.
 
-It is important to provide unique identifiers where known, any fields with default values that are omitted will be generated.
+It is important to provide unique identifiers were known, any fields with default values that are omitted will be generated.
 
 get_or_create()
 ---------------
@@ -58,7 +59,7 @@ Atomically get or create nodes in a single operation::
     assert people[0] == people_with_jill[0]
     assert people[1] == people_with_jill[1]
 
-This is useful for ensuring specific nodes exist, only and all required properties must be specified to ensure
+This is useful for ensuring specific nodes exist only and all required properties must be specified to ensure
 uniqueness. In this example 'Tim' and 'Bob' are created on the first call, and are retrieved in the second call.
 
 Additionally, get_or_create() allows the "relationship" parameter to be passed. When a relationship is specified, the
@@ -83,4 +84,3 @@ matching is done based on that relationship and not globally::
 
 In case when the only required property is unique, the operation is redundant. However with simple required properties,
 the relationship becomes a part of the unique identifier.
-

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -1,16 +1,16 @@
 Configuration
 =============
 
-Covering the neomodel 'config' module and its variables.
+This section is covering the Neomodel 'config' module and its variables.
 
 Database
 --------
 
-Set your connection details::
+Seting the connection URL::
 
     config.DATABASE_URL = 'bolt://neo4j:neo4j@localhost:7687`
 
-Disable encrypted connection (usefult for development::
+Disable encrypted connection (usefult for development)::
 
     config.ENCRYPTED_CONNECTION = False
 
@@ -21,21 +21,22 @@ Adjust connection pool size::
 Enable automatic index and constraint creation
 ----------------------------------------------
 
-After a StructuredNode definition neomodel can install the corresponding constraints and indexes at compile time.
-However this method is only recommended for testing::
+After the definition of a `StructuredNode`, Neomodel can install the corresponding 
+constraints and indexes at compile time. However this method is only recommended for testing::
 
     from neomodel import config
     # before loading your node definitions
     config.AUTO_INSTALL_LABELS = True
 
-Neomodel provides a script `neomodel_install_labels` for the task, however if you want to handle this manually see below.
+Neomodel also provides the `neomodel_install_labels` scripr for this task, 
+however if you want to handle this manually see below.
 
 Install indexes and constraints for a single class::
 
     from neomodel import install_labels
     install_labels(YourClass)
 
-Or for your entire 'schema' ::
+Or for an entire 'schema' ::
 
     import yourapp  # make sure your app is loaded
     from neomodel import install_all_labels

--- a/doc/source/extending.rst
+++ b/doc/source/extending.rst
@@ -4,11 +4,11 @@ Extending neomodel
 
 Inheritance
 -----------
-You may want to create a 'base node' classes which extends the functionality which neomodel provides
+Neomodel extends the ability to compose classes by inheritance to the backend. This 
+makes it possible to create a node class which extends the functionality that neomodel provides
 (such as `neomodel.contrib.SemiStructuredNode`).
 
-Or just have common methods and properties you want to share.
-This can be achieved using the `__abstract_node__` property on any base classes you wish to inherit from::
+Creating purely abstract classes is achieved using the `__abstract_node__` property on base classes::
 
     class User(StructuredNode):
         __abstract_node__ = True
@@ -23,7 +23,7 @@ This can be achieved using the `__abstract_node__` property on any base classes 
 
 Mixins
 ------
-You can use mixins to share the functionality between nodes classes::
+Mixins can be used to share functionality between nodes classes::
 
     class UserMixin(object):
         name = StringProperty(unique_index=True)
@@ -42,13 +42,14 @@ You can use mixins to share the functionality between nodes classes::
     jim = Shopper(name='jimmy', balance=300).save()
     jim.credit_account(50)
 
-Make sure your mixins *dont* inherit from `StructuredNode` and your concrete class does.
+Please note that it has to be ensured that the mixins *do not* inherit 
+from `StructuredNode` but that the concrete class does.
 
 Overriding the StructuredNode constructor
 -----------------------------------------
 
-When defining classes that have a custom `__init__(self, ...)` method,
-you must always call `super()` for the neomodel magic to work::
+When defining classes that have a custom `__init__(self, ...)` constructor,
+the `super()` class constructor must also be called::
 
     class Item(StructuredNode):
         name = StringProperty(unique_index=True)
@@ -61,5 +62,6 @@ you must always call `super()` for the neomodel magic to work::
 
             super(Item, self).__init__(self, *args, **kwargs)
 
-It's important to note that `StructuredNode`'s constructor will override properties set (which are defined on the class).
-So you must pass the values in via `kwargs` (as above). You may set them after calling the constructor but it does skip validation.
+It is important to note that `StructuredNode`'s constructor will override properties set (which are defined on the class).
+Therefore constructor parameters must be passed via `kwargs` (as above). 
+These can also be set after calling the constructor but this would skip validation.

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -10,7 +10,7 @@ Before executing any neomodel code set the connection url::
     from neomodel import config
     config.DATABASE_URL = 'bolt://neo4j:neo4j@localhost:7687'  # default
 
-This needs to be called early on in your app, if you are using Django the settings.py file is ideal.
+This needs to be called early on in your app, if you are using Django the `settings.py` file is ideal.
 
 If you are using your neo4j server for the first time you will need to change the default password.
 This can be achieved by visiting the neo4j admin panel (default: http://localhost:7474 ).
@@ -49,13 +49,13 @@ Below is a definition of two types of node `Person` and `Country`::
 
 
 There is one type of relationship present `IS_FROM`, we are defining two different ways for traversing it
-one accessible via Person objects and one via Country objects
+one accessible via `Person` objects and one via `Country` objects
 
 We can use the `Relationship` class as opposed to the `RelationshipTo` or `RelationshipFrom`
 if we don't want to specify a direction.
 
-Neomodel automatically creates a label for each StructuredNode class in the database
- with the corresponding indexes and constraints.
+Neomodel automatically creates a label for each `StructuredNode` class in the database
+with the corresponding indexes and constraints.
 
 Setup constraints and indexes
 =============================
@@ -75,10 +75,10 @@ For deleting all existing constraints and indexes from database, neomodel provid
 
 After executing, it will print all indexes and constraints it has deleted.
 
-Create, Save, Delete
-====================
+Create, Update, Delete
+======================
 
-Using convenient methods::
+Using convenience methods such as::
 
     jim = Person(name='Jim', age=3).save()
     jim.age = 4
@@ -87,8 +87,8 @@ Using convenient methods::
     jim.refresh() # reload properties from neo
     jim.id # neo4j internal id
 
-Finding nodes
-=============
+Retrieving nodes
+================
 
 Using the '.nodes' class property::
 

--- a/doc/source/hooks.rst
+++ b/doc/source/hooks.rst
@@ -2,18 +2,18 @@
 Hooks
 =====
 
-You may define the following hook methods on your `StructuredNode` sub classes::
+The following hook methods can be defined on `StructuredNode` sub classes::
 
     pre_save, post_save, pre_delete, post_delete, post_create
 
-All take no arguments. An example of the post creation hook::
+All these hook methods do not accept any arguments. An example of the post creation hook is as follows::
 
     class Person(StructuredNode):
 
         def post_create(self):
             email_welcome_message(self)
 
-Note the `post_create` hook is not called by `get_or_create` and `create_or_update` methods.
+Note that the `post_create` hook is not called by the `get_or_create` and `create_or_update` methods.
 
 Save hooks are called regardless of wether the node is new or not.
 To determine if a node exists in `pre_save`, check for an `id` attribute on self.
@@ -21,10 +21,10 @@ To determine if a node exists in `pre_save`, check for an `id` attribute on self
 Hooks on relationships
 ----------------------
 
-The hooks `pre_save` and `post_save` are available on `StructuredRel` models.
-They are executed when calling save on the object directly or when creating a new relationship via connect.
+The hook methods `pre_save` and `post_save` are available on `StructuredRel` models.
+They are executed when calling save on the object directly or when creating a new relationship via `connect`.
 
-Note that in the pre_save call during a connect the start and end nodes are not available.
+Note that in the `pre_save` call during a `connect` the start and end nodes are not available.
 
 Django signals
 ==============

--- a/doc/source/module_documentation.rst
+++ b/doc/source/module_documentation.rst
@@ -2,6 +2,13 @@
 Modules documentation
 =====================
 
+Database
+--------
+.. module:: neomodel.util
+.. autoclass:: neomodel.util.Database
+  :members:
+  :undoc-members:
+  
 Core
 ----
 .. automodule:: neomodel.core

--- a/doc/source/properties.rst
+++ b/doc/source/properties.rst
@@ -17,22 +17,21 @@ The following properties are available on nodes and relationships:
 Defaults
 ========
 
-*Default values* you may provide a default value to any property, this can
-also be a :term:`function` or any callable::
+Default values can be specified for any property, even as the result of a 
+:term:`function` or other callable object::
 
         from uuid import uuid4
         my_id = StringProperty(unique_index=True, default=uuid4)
 
-You may provide arguments as :term:`function` or :term:`lambda`::
+And in terms of a :term:`function` or :term:`lambda`::
 
         my_datetime = DateTimeProperty(default=lambda: datetime.now(pytz.utc))
 
 Choices
 =======
 
-You can specify a list of valid values for a :class:`~neomodel.properties.StringProperty`
-using the ``choices`` argument. The mapping's values are supposed to be used
-when displaying information to users::
+Choices can be specified as a mapping (dict) of valid values for a :class:`~neomodel.properties.StringProperty`
+using the ``choices`` argument. The mapping's values are used when displaying information to users::
 
     class Person(StructuredNode):
         SEXES = {'F': 'Female', 'M': 'Male', 'O': 'Other'}
@@ -42,12 +41,12 @@ when displaying information to users::
     tim.sex # M
     tim.get_sex_display() # 'Male'
 
-The value's validity will be checked both when saved and loaded from Neo4j.
+The value's validity will be checked both when saved and loaded from the database.
 
 Array Properties
 ================
-Neo4j supports arrays as a property value, these are used with the `ArrayProperty` class.
-You may optionally provide a list element type as the first argument to ArrayProperty with another property instance::
+Neomodel supports arrays via the `ArrayProperty` class and a list element type 
+can optionally be provided as the first argument::
 
     class Person(StructuredNode):
         names = ArrayProperty(StringProperty(), required=True)
@@ -60,7 +59,7 @@ Unique Identifiers
 ==================
 All nodes in neo4j have an internal id (accessible by the 'id' property in neomodel)
 however these should not be used by an application.
-neomodel provides the `UniqueIdProperty` to generate unique identifiers for your nodes (with an unique index)::
+Neomodel provides the `UniqueIdProperty` to generate unique identifiers for nodes (with a unique index)::
 
     class Person(StructuredNode):
         uid = UniqueIdProperty()
@@ -70,16 +69,16 @@ neomodel provides the `UniqueIdProperty` to generate unique identifiers for your
 Dates and times
 ===============
 
-The *DateTimeProperty* accepts datetime.datetime objects of any timezone and stores them as a UTC epoch value.
+The *DateTimeProperty* accepts `datetime.datetime` objects of any timezone and stores them as a UTC epoch value.
 These epoch values are inflated to datetime.datetime objects with the UTC timezone set.
 
 The *DateProperty* accepts datetime.date objects which are stored as a string property 'YYYY-MM-DD'.
 
-You can use `default_now` argument to store the current time by default::
+The `default_now` parameter specifies the current time as the default value::
 
         created = DateTimeProperty(default_now=True)
 
-You can enforce timezones by setting the config var NEOMODEL_FORCE_TIMEZONE=1.
+Enforcing a specific timezone is done by setting the config variable` NEOMODEL_FORCE_TIMEZONE=1`.
 
 Other properties
 ================
@@ -88,10 +87,11 @@ Other properties
 * `RegexProperty` - passing in a validator regex: `RegexProperty(expression=r'\d\w')`
 * `NormalProperty` - use one method (normalize) to inflate and deflate.
 
+
 Aliasing properties
 ===================
 
-Allows aliasing to other properties can be useful to provide 'magic' behaviour, (only supported on `StructuredNodes`)::
+Allows aliasing to other properties which can be useful to provide 'magic' behaviour, (only supported on `StructuredNodes`)::
 
     class Person(StructuredNode):
         full_name = StringProperty(index=True)
@@ -102,8 +102,8 @@ Allows aliasing to other properties can be useful to provide 'magic' behaviour, 
 Independent database property name
 ==================================
 
-You can specify an independent property name with 'db_property', which is used on database level. It behaves like Django's 'db_column'.
-This is useful for e.g. hiding graph properties behind a python property::
+You can specify an independent property name with 'db_property', which is used at the database level. It behaves like Django's 'db_column'.
+This is useful when hiding graph properties behind a python property::
 
     class Person(StructuredNode):
         name_ = StringProperty(db_property='name')
@@ -115,4 +115,3 @@ This is useful for e.g. hiding graph properties behind a python property::
         @name.setter
         def name(self, value):
             self.name_ = value
-

--- a/doc/source/queries.rst
+++ b/doc/source/queries.rst
@@ -2,7 +2,7 @@
 Advanced queries
 ================
 
-Neomodel contains an API for querying sets of nodes without needing to write cypher::
+Neomodel contains an API for querying sets of nodes without having to write cypher::
 
     class SupplierRel(StructuredRel):
         since = DateTimeProperty(default=datetime.now)
@@ -22,7 +22,7 @@ Neomodel contains an API for querying sets of nodes without needing to write cyp
 Node sets and filtering
 =======================
 
-The `nodes` property on a class is the set of all nodes in the database of that type contained.
+The `nodes` property of a class returns all nodes of that type from the database.
 
 This set (or `NodeSet`) can be iterated over and filtered on. Under the hood it uses labels introduced in neo4j 2::
 
@@ -34,7 +34,7 @@ This set (or `NodeSet`) can be iterated over and filtered on. Under the hood it 
     except Coffee.DoesNotExist:
         print "Couldn't find coffee 'Java'"
 
-The filter method borrows the same django filter format with double underscore prefixed operators:
+The filter method borrows the same Django filter format with double underscore prefixed operators:
 
 - lt - less than
 - gt - greater than
@@ -58,8 +58,9 @@ Complex lookups with ``Q`` objects
 ==================================
 
 Keyword argument queries -- in `filter`,
-etc. -- are "AND"ed together. If you need to execute more complex queries (for
-example, queries with ``OR`` statements), you can use `Q objects <neomodel.Q>`.
+etc. -- are "AND"ed together. To execute more complex queries (for
+example, queries with ``OR`` statements), `Q objects <neomodel.Q>` can 
+be used.
 
 A `Q object` (``neomodel.Q``) is an object
 used to encapsulate a collection of keyword arguments. These keyword arguments
@@ -82,7 +83,7 @@ This is equivalent to the following SQL ``WHERE`` clause::
 
     WHERE name STARTS WITH 'Py' OR name STARTS WITH 'Jav'
 
-You can compose statements of arbitrary complexity by combining ``Q`` objects
+Statements of arbitrary complexity can be composed by combining ``Q`` objects
 with the ``&`` and ``|`` operators and use parenthetical grouping. Also, ``Q``
 objects can be negated using the ``~`` operator, allowing for combined lookups
 that combine both a normal query and a negated (``NOT``) query::
@@ -91,8 +92,8 @@ that combine both a normal query and a negated (``NOT``) query::
 
 Each lookup function that takes keyword-arguments
 (e.g. `filter`, `exclude`, `get`) can also be passed one or more
-``Q`` objects as positional (not-named) arguments. If you provide multiple
-``Q`` object arguments to a lookup function, the arguments will be "AND"ed
+``Q`` objects as positional (not-named) arguments. If multiple
+``Q`` object arguments are provided to a lookup function, the arguments will be "AND"ed
 together. For example::
 
     Lang.nodes.filter(
@@ -100,7 +101,7 @@ together. For example::
         Q(year=2005) | Q(year=2006)
     )
 
-... roughly translates into the Cypher::
+This roughly translates to the following Cypher query::
 
     MATCH (lang:Lang) WHERE name STARTS WITH 'Py'
         AND (year = 2005 OR year = 2006)
@@ -116,7 +117,7 @@ precede the definition of any keyword arguments. For example::
         name__startswith='Py',
     )
 
-... would be a valid query, equivalent to the previous example;
+This would be a valid query, equivalent to the previous example;
 
 Has a relationship
 ==================
@@ -125,7 +126,7 @@ The `has` method checks for existence of (one or more) relationships, in this ca
 
     Coffee.nodes.has(suppliers=True)
 
-This can be negated `suppliers=False`, should you wish to find `Coffee` nodes without `suppliers`.
+This can be negated by setting `suppliers=False`, to find `Coffee` nodes without `suppliers`.
 
 Iteration, slicing and more
 ===========================
@@ -141,7 +142,7 @@ Iteration, slicing and counting is also supported::
 
 The slice syntax returns a NodeSet object which can in turn be chained.
 
-Length and boolean methods dont return NodeSet objects so cant be chained further::
+Length and boolean methods dont return NodeSet objects and cannot be chained further::
 
     # Count with __len__
     print len(Coffee.nodes.filter(price__gt=2))
@@ -154,26 +155,26 @@ Filtering by relationship properties
 
 Filtering on relationship properties is also possible using the `match` method. Note that again these relationships must have a definition.::
 
-    nescafe = Coffee.nodes.get(name="Nescafe")
+    coffee_brand = Coffee.nodes.get(name="BestCoffeeEver")
 
-    for supplier in nescafe.suppliers.match(since_lt=january):
-        print supplier.name
+    for supplier in coffee_brand.suppliers.match(since_lt=january):
+        print(supplier.name)
 
 Ordering by property
 ====================
 
-To order results by a particular property, use the `order_by` method::
+Ordering results by a particular property is done via th `order_by` method::
 
     # Ascending sort
     for coffee in Coffee.nodes.order_by('price'):
-        print coffee, coffee.price
+        print(coffee, coffee.price)
 
     # Descending sort
     for supplier in Supplier.nodes.order_by('-delivery_cost'):
-        print supplier, supplier.delivery_cost
+        print(supplier, supplier.delivery_cost)
 
 
-To remove ordering from a previously defined query, pass `None` to `order_by`::
+Removing the ordering from a previously defined query, is done by passing `None` to `order_by`::
 
     # Sort in descending order
     suppliers = Supplier.nodes.order_by('-delivery_cost')

--- a/doc/source/relationships.rst
+++ b/doc/source/relationships.rst
@@ -99,7 +99,7 @@ further defined. ::
         Base class for defining some basic sort of an actor in a system.
         
         The base actor is defined by its name and a `friends_with` 
-        relationship
+        relationship.
         """
         name = neomodel.StringProperty(required = True, unique_index = True)
         friends_with = neomodel.RelationshipTo("BasePerson", "FRIENDS_WITH", model = PersonalRelationship)
@@ -107,14 +107,14 @@ further defined. ::
     class TechnicalPerson(BasePerson):
         """
         A Technical person specialises BasePerson by adding their 
-        expertise
+        expertise.
         """
         expertise = neomodel.StringProperty(required = True)
         
     class PilotPerson(BasePerson):
         """
         A pilot person specialises BasePerson by adding the type of 
-        airplane they can operate
+        airplane they can operate.
         """
         airplane = neomodel.StringProperty(required = True)
         
@@ -155,7 +155,7 @@ Automatic class resolution
 --------------------------
 
 Neomodel is able to transform nodes to objects, automatically, via a *node-class registry* 
-that is progreessively built up during the definition of the models.
+that is progressively built up during the definition of the models.
 
 The dictionary provides a mapping from the set of labels associated with a node to the class 
 that is implied by this set of labels. In the example above, the *node-class registry* would contain 

--- a/doc/source/relationships.rst
+++ b/doc/source/relationships.rst
@@ -2,7 +2,8 @@
 Relationships
 =============
 
-Directionless relationships, first argument the class second the neo4j relationship::
+Establishing an undirected relationship between two entities is done via the `Relationship` 
+class. This requires the class of the connected entity as well as the type of the relationship.
 
     class Person(StructuredNode):
         friends = Relationship('Person', 'FRIEND')
@@ -16,8 +17,8 @@ This avoids cyclic imports::
 
 Cardinality
 ===========
-It's possible to (softly) enforce cardinality restrictions on your relationships.
-Remember this needs to be declared on both sides of the definition::
+It is possible to (softly) enforce cardinality constraints on your relationships.
+Remember this needs to be declared on both sides of the relationship definition::
 
     class Person(StructuredNode):
         car = RelationshipTo('Car', 'OWNS', cardinality=One)
@@ -25,16 +26,17 @@ Remember this needs to be declared on both sides of the definition::
     class Car(StructuredNode):
         owner = RelationshipFrom('Person', 'OWNS', cardinality=One)
 
-The following cardinality classes are available:
+The following cardinality constraints are available:
 
 ===================================================  ========================================
 :class:`~neomodel.cardinality.ZeroOrOne`             :class:`~neomodel.cardinality.One`
 :class:`~neomodel.cardinality.ZeroOrMore` (default)  :class:`~neomodel.cardinality.OneOrMore`
 ===================================================  ========================================
 
-If cardinality is broken by existing data a :class:`~neomodel.exception.CardinalityViolation`
+If a cardinality constrain is violated by existing data a :class:`~neomodel.exception.CardinalityViolation`
 exception is raised.
-On attempting to break a cardinality restriction a
+
+On attempting to violate a cardinality constrain a 
 :class:`~neomodel.exception.AttemptedCardinalityViolation` is raised.
 
 Properties
@@ -56,7 +58,8 @@ Neomodel uses :mod:`~neomodel.relationship` models to define the properties stor
     rel.since # datetime object
 
 
-These can be passed in when calling the connect method::
+The data to populate these properties when establishing a connection can be supplied 
+to the `connect` method::
 
     rel = jim.friends.connect(bob,
                               {'since': yesterday, 'met': 'Paris'})
@@ -75,8 +78,8 @@ This is only available for relationships with a defined relationship model::
 Relationship Uniqueness
 =======================
 
-By default in neomodel there is only one relationship of one type between two nodes
-unless you define different properties when calling connect. neomodel utilises `CREATE UNIQUE` in cypher to achieve this.
+By default neomodel applies only one relationship instance between two node instances and 
+this is achieved via use of `CREATE UNIQUE`.
 
 Relationships and Inheritance
 =============================
@@ -179,9 +182,6 @@ If the exception is not handled, it produces an error message that returns the l
 was retrieved from the database as well as the current *node-class registry*. These two pieces of 
 information can be used to debug the model mismatch further.
     
-
-
-        
 
 Explicit Traversal
 ==================

--- a/doc/source/transactions.rst
+++ b/doc/source/transactions.rst
@@ -1,5 +1,16 @@
+============
 Transactions
-------------
+============
+
+This section outlines the way neomodel handles transaction management. For a 
+thorough background on how the Neo4J DBMS handles sessions and transactions, 
+please refer to `the documentation <https://neo4j.com/docs/operations-manual/
+current/clustering/introduction/#causal-clustering-read-replicas>`_.
+
+
+Basic usage
+-----------
+
 Transactions can be used via a context manager::
 
     from neomodel import db
@@ -33,12 +44,65 @@ If you're using celery or another task scheduler it's advised to wrap each task 
     def send_email(user):
         ...
 
-Transactions can also be designated as *write transactions*.
-Marking as a write transaction may not matter on a single-instance Neo4J, but is vital in a Neo4J causal cluster where writes must be sent to the leader node.
-For performance purposes, this should be limited to transactions that write/delete data, or any situation where talking to the leader node is essential::
+
+Explicit Transactions
+---------------------
+
+Neomodel also supports  `epxlicit transactions <https://neo4j.com/docs/
+api/python-driver/current/transactions.html>`_ that are pre-designated as either *read* or *write*. 
+
+This is vital when using neomodel over a `Neo4J causal cluster <https://neo4j.com/docs/
+operations-manual/current/clustering/>`_ because internally, queries will be rerouted to different 
+servers depending on their designation. 
+
+Note here that this functionality is enabled when `bolt+routing:// <https://neo4j.com/docs/
+developer-manual/current/drivers/client-applications/#routing_drivers_bolt_routing>`_ has been 
+specified as the scheme of the connection URL, as opposed to :code:`bolt://` which 
+is more common in single instance deployments.
+
+Read transactions do not modify the database state and therefore only include CYPHER operations that 
+simply return results. Write transactions however **do modify the database state** and therefore 
+include all CYPHER operations that can potentially Create, Update or Delete Nodes and / or Relationships. 
+
+*By default, starting a transaction without explicitly specifying its type, results in a* **WRITE** 
+*transaction*.
+
+Similarly to `Basic Usage`_, Neomodel designates transactions in the following ways:
+
+With distinct context managers::
+
+    with db.read_transaction:
+        ...
+        
+    with db.write_transaction:
+        ...
+        
+    with db.transaction:
+        # This designates the transaction as WRITE even if 
+        # the the enclosed block of code will not modify the 
+        # database state.
+        
+
+With function decorators::
 
     @db.write_transaction
     def update_user_name(uid, name):
         user = Person.nodes.filter(uid=uid)[0]
         user.name = name
         user.save()
+        
+    @db.read.transaction
+    def get_all_users():
+        return Person.nodes.all()
+        
+    @db.trasaction # Be default a WRITE transaction
+    ...
+        
+
+With explicit designation::
+
+    db.begin("WRITE")
+    ...
+    db.begin("READ")
+    ...
+    db.begin() # By default a **WRITE** transaction

--- a/neomodel/__init__.py
+++ b/neomodel/__init__.py
@@ -15,7 +15,7 @@ from .properties import (StringProperty, IntegerProperty, AliasProperty,
                          FloatProperty, BooleanProperty, DateTimeProperty, DateProperty,
                          NormalizedProperty, RegexProperty, EmailProperty,
                          JSONProperty, ArrayProperty, UniqueIdProperty)
-
+                         
 __author__ = 'Robin Edwards'
 __email__ = 'robin.ge@gmail.com'
 __license__ = 'MIT'

--- a/neomodel/core.py
+++ b/neomodel/core.py
@@ -171,7 +171,8 @@ class NodeMeta(type):
 
             if config.AUTO_INSTALL_LABELS:
                 install_labels(cls)
-
+            db._NODE_CLASS_REGISTRY[frozenset(cls.inherited_labels())] = cls
+            
         return cls
 
 

--- a/neomodel/exceptions.py
+++ b/neomodel/exceptions.py
@@ -48,14 +48,20 @@ class ModelDefinitionMismatch(NeomodelException):
         to an object
         
         :param db_node: Neo4j driver node object
-        :param current_node_class_registry: Dictionary that maps frozeset of node 
-        labels to model classes
+        :param current_node_class_registry: Dictionary that maps frozenset of
+               node labels to model classes
         """
         self.db_node = db_node
-        self.current_node_class_registry=current_node_class_registry
+        self.current_node_class_registry = current_node_class_registry
         
     def __str__(self):
-        return "Node with labels {} does not resolve to any of the known objects\n{}\n".format(",".join(db_node.labels), "\n".join(list(map(lambda x:"{} --> {}".format(",".join(x[0]),x[1]),current_node_class_registry.items()))))
+        node_labels = ",".join(self.db_node.labels)
+        ncr_items = list(map(lambda x:"{} --> {}".format(",".join(x[0]), x[1]),
+                             self.current_node_class_registry.items()))
+        ncr_items_multiline = "\n".join(ncr_items)
+
+        return "Node with labels {} does not resolve to any of the known " \
+               "objects\n{}\n".format(node_labels, ncr_items_multiline)
 
 
 class ConstraintValidationFailed(ValueError, NeomodelException):

--- a/neomodel/exceptions.py
+++ b/neomodel/exceptions.py
@@ -31,6 +31,33 @@ class CardinalityViolation(NeomodelException):
             .format(self.rel_manager, self.actual)
 
 
+class ModelDefinitionMismatch(NeomodelException):
+    """
+    Raised when it is impossible to resolve a Neo4j driver Node to a 
+    specific object. This can happen as a result of a query returning 
+    nodes for which class definitions do exist but have not been loaded 
+    (or rather imported) or because the retrieved nodes contain more 
+    labels for a known class.
+    
+    In either of these cases the mismatch must be reported
+    """
+    
+    def __init__(self, db_node, current_node_class_registry):
+        """
+        Initialises the exception with the database node that failed to resolve 
+        to an object
+        
+        :param db_node: Neo4j driver node object
+        :param current_node_class_registry: Dictionary that maps frozeset of node 
+        labels to model classes
+        """
+        self.db_node = db_node
+        self.current_node_class_registry=current_node_class_registry
+        
+    def __str__(self):
+        return "Node with labels {} does not resolve to any of the known objects\n{}\n".format(",".join(db_node.labels), "\n".join(list(map(lambda x:"{} --> {}".format(",".join(x[0]),x[1]),current_node_class_registry.items()))))
+
+
 class ConstraintValidationFailed(ValueError, NeomodelException):
     def __init__(self, msg):
         self.message = msg

--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -439,10 +439,8 @@ class QueryBuilder(object):
 
     def _execute(self):
         query = self.build_query()
-        results, _ = db.cypher_query(query, self._query_params)
-        if results:
-            return [self._ast['result_class'].inflate(n[0]) for n in results]
-        return []
+        results, _ = db.cypher_objectaware_query(query, self._query_params)
+        return results  
 
 
 class BaseSet(object):

--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -439,10 +439,16 @@ class QueryBuilder(object):
 
     def _execute(self):
         query = self.build_query()
-        results, _ = db.cypher_objectaware_query(query, self._query_params)
-        return results  
-
-
+        results, _ = db.cypher_query(query, self._query_params, resolve_objects=True)            
+        # The following is not as elegant as it could be but had to be copied from the 
+        # version prior to cypher_query with the resolve_objects capability.
+        # It seems that certain calls are only supposed to be focusing to the first 
+        # result item returned (?)
+        if results:
+            return [n[0] for n in results]
+        return []
+        
+        
 class BaseSet(object):
     """
     Base class for all node sets.

--- a/neomodel/relationship.py
+++ b/neomodel/relationship.py
@@ -58,7 +58,10 @@ class StructuredRel(StructuredRelBase):
 
         :return: StructuredNode
         """
-        return db.cypher_query("MATCH (aNode) WHERE id(aNode)={nodeid} return aNode".format(nodeid=self._start_node_id), resolve_objects = True)[0][0][0]
+        return db.cypher_query("MATCH (aNode) "
+                               "WHERE id(aNode)={nodeid} "
+                               "RETURN aNode".format(nodeid=self._start_node_id),
+                               resolve_objects = True)[0][0][0]
       
     def end_node(self):
         """
@@ -66,7 +69,10 @@ class StructuredRel(StructuredRelBase):
 
         :return: StructuredNode
         """
-        return db.cypher_query("MATCH (aNode) WHERE id(aNode)={nodeid} return aNode".format(nodeid=self._end_node_id), resolve_objects = True)[0][0][0]
+        return db.cypher_query("MATCH (aNode) "
+                               "WHERE id(aNode)={nodeid} "
+                               "RETURN aNode".format(nodeid=self._end_node_id),
+                               resolve_objects = True)[0][0][0]
 
     @classmethod
     def inflate(cls, rel):

--- a/neomodel/relationship.py
+++ b/neomodel/relationship.py
@@ -58,7 +58,7 @@ class StructuredRel(StructuredRelBase):
 
         :return: StructuredNode
         """
-        return db.cypher_objectaware_query("MATCH (aNode) WHERE id(aNode)={nodeid} return aNode".format(nodeid=self._start_node_id))[0][0]
+        return db.cypher_query("MATCH (aNode) WHERE id(aNode)={nodeid} return aNode".format(nodeid=self._start_node_id), resolve_objects = True)[0][0][0]
       
     def end_node(self):
         """
@@ -66,7 +66,7 @@ class StructuredRel(StructuredRelBase):
 
         :return: StructuredNode
         """
-        return db.cypher_objectaware_query("MATCH (aNode) WHERE id(aNode)={nodeid} return aNode".format(nodeid=self._end_node_id))[0][0]
+        return db.cypher_query("MATCH (aNode) WHERE id(aNode)={nodeid} return aNode".format(nodeid=self._end_node_id), resolve_objects = True)[0][0][0]
 
     @classmethod
     def inflate(cls, rel):

--- a/neomodel/relationship.py
+++ b/neomodel/relationship.py
@@ -58,7 +58,7 @@ class StructuredRel(StructuredRelBase):
 
         :return: StructuredNode
         """
-        return db.cypher_objectaware_query("MATCH (aNode) WHERE id(aNode)={nodeid}".format(nodeid=self._start_node_id))[0][0]
+        return db.cypher_objectaware_query("MATCH (aNode) WHERE id(aNode)={nodeid} return aNode".format(nodeid=self._start_node_id))[0][0]
       
     def end_node(self):
         """
@@ -66,7 +66,7 @@ class StructuredRel(StructuredRelBase):
 
         :return: StructuredNode
         """
-        return db.cypher_objectaware_query("MATCH (aNode) WHERE id(aNode)={nodeid}".format(nodeid=self._end_node_id))[0][0]
+        return db.cypher_objectaware_query("MATCH (aNode) WHERE id(aNode)={nodeid} return aNode".format(nodeid=self._end_node_id))[0][0]
 
     @classmethod
     def inflate(cls, rel):

--- a/neomodel/relationship.py
+++ b/neomodel/relationship.py
@@ -58,21 +58,15 @@ class StructuredRel(StructuredRelBase):
 
         :return: StructuredNode
         """
-        node = self._start_node_class()
-        node.id = self._start_node_id
-        node.refresh()
-        return node
-
+        return db.cypher_objectaware_query("MATCH (aNode) WHERE id(aNode)={nodeid}".format(nodeid=self._start_node_id))[0][0]
+      
     def end_node(self):
         """
         Get end node
 
         :return: StructuredNode
         """
-        node = self._end_node_class()
-        node.id = self._end_node_id
-        node.refresh()
-        return node
+        return db.cypher_objectaware_query("MATCH (aNode) WHERE id(aNode)={nodeid}".format(nodeid=self._end_node_id))[0][0]
 
     @classmethod
     def inflate(cls, rel):

--- a/neomodel/relationship_manager.py
+++ b/neomodel/relationship_manager.py
@@ -50,7 +50,7 @@ class RelationshipManager(object):
 
     def _check_node(self, obj):
         """check for valid node i.e correct class and is saved"""
-        if not isinstance(obj, self.definition['node_class']):
+        if not issubclass(type(obj), self.definition['node_class']):
             raise ValueError("Expected node of class " + self.definition['node_class'].__name__)
         if not hasattr(obj, 'id'):
             raise ValueError("Can't perform operation on unsaved node " + repr(obj))

--- a/neomodel/util.py
+++ b/neomodel/util.py
@@ -125,9 +125,12 @@ class Database(local):
 
     def _object_resolution(self, result_list):
         """
-        Performs in place automatic object resolution on a set of results returned by cypher_query.
-        The function operates recursively in order to be able to resolve Nodes within nested list structures.
-        Not meant to be called directly, used primarily by cypher_query.
+        Performs in place automatic object resolution on a set of results
+        returned by cypher_query.
+
+        The function operates recursively in order to be able to resolve Nodes
+        within nested list structures. Not meant to be called directly,
+        used primarily by cypher_query.
         
         :param result_list: A list of results as returned by cypher_query.
         :type list:
@@ -144,7 +147,8 @@ class Database(local):
                     resolved_object = a_result_attribute[1]
                     
                     if type(a_result_attribute[1]) is Node:
-                        resolved_object = self._NODE_CLASS_REGISTRY[frozenset(a_result_attribute[1].labels)].inflate(a_result_attribute[1])
+                        resolved_object = self._NODE_CLASS_REGISTRY[frozenset(a_result_attribute[1].labels)].inflate(
+                            a_result_attribute[1])
                         
                     if type(a_result_attribute[1]) is list:
                         resolved_object = self._object_resolution([a_result_attribute[1]])                    
@@ -174,7 +178,7 @@ class Database(local):
         :type: bool
         :param retry_on_session_expire: Whether or not to attempt the same query again if the transaction has expired
         :type: bool        
--        :param resolve_objects: Whether to attempt to resolve the returned nodes to data model objects automatically
+        :param resolve_objects: Whether to attempt to resolve the returned nodes to data model objects automatically
         :type: bool
         """
         
@@ -212,7 +216,9 @@ class Database(local):
         except SessionError:
             if retry_on_session_expire:
                 self.set_connection(self.url)
-                return self.cypher_query(query=query, params=params, handle_unique=handle_unique,
+                return self.cypher_query(query=query,
+                                         params=params,
+                                         handle_unique=handle_unique,
                                          retry_on_session_expire=False)
             raise
 

--- a/neomodel/util.py
+++ b/neomodel/util.py
@@ -10,6 +10,7 @@ from neo4j.v1 import GraphDatabase, basic_auth, CypherError, SessionError
 from . import config
 from .exceptions import UniqueProperty, ConstraintValidationFailed,  ModelDefinitionMismatch
 
+
 if sys.version_info >= (3, 0):
     from urllib.parse import urlparse
 else:
@@ -205,10 +206,10 @@ class TransactionProxy(object):
         if exc_type is CypherError:
             if exc_value.code == u'Neo.ClientError.Schema.ConstraintValidationFailed':
                 raise UniqueProperty(exc_value.message)
-
+                
         if not exc_value:
-            self.db.commit()
-
+            self.db.commit()                            
+            
     def __call__(self, func):
         def wrapper(*args, **kwargs):
             with self:

--- a/neomodel/util.py
+++ b/neomodel/util.py
@@ -92,6 +92,10 @@ class Database(local):
     @property
     def write_transaction(self):
         return TransactionProxy(self, access_mode="WRITE")
+        
+    @property
+    def read_transaction(self):
+        return TransactionProxy(self, access_mode="READ")        
 
     @ensure_connection
     def begin(self, access_mode=None):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -28,7 +28,7 @@ def pytest_sessionstart(session):
     
     config.DATABASE_URL = os.environ.get('NEO4J_BOLT_URL', 'bolt://neo4j:neo4j@localhost:7687')
     config.AUTO_INSTALL_LABELS = True
-
+    
     try:
         # Clear the database if required
         database_is_populated, _ = db.cypher_query("MATCH (a) return count(a)>0 as database_is_populated")

--- a/test/test_issue283.py
+++ b/test/test_issue283.py
@@ -1,0 +1,165 @@
+"""
+Provides a test case for issue 283 - "Inheritance breaks".
+
+The issue is outlined here: https://github.com/neo4j-contrib/neomodel/issues/283
+More infomration about the same issue at: https://github.com/aanastasiou/neomodelInheritanceTest
+
+The following example uses a recursive relationship for economy, but the 
+idea remains the same: "Instantiate the correct type of node at the end of 
+a relationship as specified by the model"
+"""
+
+import os
+import neomodel
+import datetime
+import pytest
+
+def _setup():
+    # Setting up
+    neo4jUsername = os.environ['NEO4J_USERNAME']
+    neo4jPassword = os.environ['NEO4J_PASSWORD']
+    dbConURI = "bolt://{uname}:{pword}@localhost:7687".format(uname=neo4jUsername, pword=neo4jPassword)
+
+    #This must be called before any further calls to neomodel.
+    neomodel.db.set_connection(dbConURI)    
+    
+def _cleanup():
+    neomodel.db.cypher_query("match (a:BasePerson) detach delete a")
+    neomodel.db.cypher_query("match (a:BaseOtherPerson) detach delete a")
+    
+
+
+class PersonalRelationship(neomodel.StructuredRel):
+    """
+    A very simple relationship between two basePersons that simply records 
+    the date at which an acquaintance was established.
+    This relationship should be carried over to anything that inherits from 
+    basePerson without any further effort.
+    """
+    on_date = neomodel.DateProperty(default_now = True)
+    
+class BasePerson(neomodel.StructuredNode):
+    """
+    Base class for defining some basic sort of an actor.
+    """
+    name = neomodel.StringProperty(required = True, unique_index = True)
+    friends_with = neomodel.RelationshipTo("BasePerson", "FRIENDS_WITH", model = PersonalRelationship)
+    
+class TechnicalPerson(BasePerson):
+    """
+    A Technical person specialises BasePerson by adding their expertise
+    """
+    expertise = neomodel.StringProperty(required = True)
+    
+class PilotPerson(BasePerson):
+    """
+    A pilot person specialises BasePerson by adding the type of airplane they can operate
+    """
+    airplane = neomodel.StringProperty(required = True)
+    
+class BaseOtherPerson(neomodel.StructuredNode):
+    """
+    An obviously "wrong" class of actor to befriend BasePersons with
+    """
+    car_color = neomodel.StringProperty(required = True)
+    
+class SomePerson(BaseOtherPerson):
+    """
+    Concrete class that simply derives from BaseOtherPerson
+    """
+    pass  
+
+
+def test_issue_283_1():
+    """
+    Node objects at the end of relationships are instantiated to their 
+    corresponding object
+    """
+        
+    _setup()
+    # Create a few entities
+    A = TechnicalPerson.get_or_create({"name":"Grumpy", "expertise":"Grumpiness"})[0]
+    B = TechnicalPerson.get_or_create({"name":"Happy", "expertise":"Unicorns"})[0]
+    C = TechnicalPerson.get_or_create({"name":"Sleepy", "expertise":"Pillows"})[0]
+    
+    # Add connections
+    A.friends_with.connect(B)
+    B.friends_with.connect(C)
+    C.friends_with.connect(A)
+    
+    # If A is friends with B, then A's friends_with objects should be TechnicalPerson (!NOT basePerson!)
+    assert type(A.friends_with[0]) is TechnicalPerson    
+    _cleanup()
+        
+def test_issue_283_2():    
+    """
+    Objects descending from the specified class of a relationship's end-node are also 
+    perfectly valid to appear as end-node values too
+    """
+    
+    _setup()
+    #Create a few entities
+    # Technical Persons
+    A = TechnicalPerson.get_or_create({"name":"Grumpy", "expertise":"Grumpiness"})[0]
+    B = TechnicalPerson.get_or_create({"name":"Happy", "expertise":"Unicorns"})[0]
+    C = TechnicalPerson.get_or_create({"name":"Sleepy", "expertise":"Pillows"})[0]
+    
+    # Pilot Persons
+    D = PilotPerson.get_or_create({"name":"Porco Rosso", "airplane":"Savoia-Marchetti"})[0]
+    E = PilotPerson.get_or_create({"name":"Jack Dalton", "airplane":"Beechcraft Model 18"})[0]
+    
+    # TechnicalPersons can befriend PilotPersons and vice-versa and that's fine
+    
+    # TechnicalPersons befriend Technical Persons
+    A.friends_with.connect(B)
+    B.friends_with.connect(C)
+    C.friends_with.connect(A)
+    
+    # Pilot Persons befriend Technical Persons
+    D.friends_with.connect(E)
+    
+    # Technical Persons befriend Pilot Persons
+    A.friends_with.connect(D)
+    E.friends_with.connect(C)
+    
+    # This now means that friends_with of a TechnicalPerson can 
+    # either be TechnicalPerson or Pilot Person (!NOT basePerson!)
+    
+    assert (type(A.friends_with[0]) is TechnicalPerson) or (type(A.friends_with[0]) is PilotPerson)
+    assert (type(A.friends_with[1]) is TechnicalPerson) or (type(A.friends_with[1]) is PilotPerson)
+    assert type(D.friends_with[0]) is PilotPerson
+    _cleanup()
+    
+        
+def test_issue_283_3():        
+    """
+    If a connection between wrong types is attempted, raise an exception
+    """
+    
+    _setup()
+    #Create a few entities
+    # Technical Persons
+    A = TechnicalPerson.get_or_create({"name":"Grumpy", "expertise":"Grumpiness"})[0]
+    B = TechnicalPerson.get_or_create({"name":"Happy", "expertise":"Unicorns"})[0]
+    C = TechnicalPerson.get_or_create({"name":"Sleepy", "expertise":"Pillows"})[0]
+    
+    # Pilot Persons
+    D = PilotPerson.get_or_create({"name":"Porco Rosso", "airplane":"Savoia-Marchetti"})[0]
+    E = PilotPerson.get_or_create({"name":"Jack Dalton", "airplane":"Beechcraft Model 18"})[0]
+    
+    #Some Person    
+    F = SomePerson(car_color = "Blue").save()
+    
+    # TechnicalPersons can befriend PilotPersons and vice-versa and that's fine
+    A.friends_with.connect(B)
+    B.friends_with.connect(C)
+    C.friends_with.connect(A)
+    D.friends_with.connect(E)
+    A.friends_with.connect(D)
+    E.friends_with.connect(C)
+    
+    # Trying to befriend a Technical Person with Some Person should raise an exception
+    with pytest.raises(ValueError):
+        A.friends_with.connect(F)   
+    
+    _cleanup()

--- a/test/test_issue283.py
+++ b/test/test_issue283.py
@@ -16,6 +16,11 @@ import datetime
 import pytest
 import random
 
+try:
+    basestring
+except NameError:
+    basestring = str
+
 # Set up a very simple model for the tests
 class PersonalRelationship(neomodel.StructuredRel):
     """
@@ -112,7 +117,7 @@ def test_recursive_automatic_object_resolution():
     # correct type
     assert type(L[0][0][0][1][0][0][0][0]) is TechnicalPerson
     # Assert that primitive data types remain primitive data types
-    assert type( L[0][0][0][1][0][1][0][1][0][0]) is str
+    assert issubclass(type(L[0][0][0][1][0][1][0][1][0][0]), basestring)
     
     A.delete()
     B.delete()

--- a/test/test_issue283.py
+++ b/test/test_issue283.py
@@ -215,7 +215,7 @@ def test_failed_object_resolution():
     
     # Now try to instantiate a RandomPerson
     A = TechnicalPerson.get_or_create({"name":"Grumpy", "expertise":"Grumpiness"})[0]
-    with pytest.raises(neomodel.exception.ModelDefinitionMismatch):        
+    with pytest.raises(neomodel.exceptions.ModelDefinitionMismatch):        
         for some_friend in A.friends_with:
             print(some_friend.name)
             
@@ -248,6 +248,6 @@ def test_node_label_mismatch():
     # One of them is UltraTechnicalPerson which would be returned as a valid node to a friends_with query
     # but is currently unknown to the node class registry.
     A = TechnicalPerson.get_or_create({"name":"Grumpy", "expertise":"Grumpiness"})[0]
-    with pytest.raises(neomodel.exception.ModelDefinitionMismatch):            
+    with pytest.raises(neomodel.exceptions.ModelDefinitionMismatch):            
         for some_friend in A.friends_with:
             print(some_friend.name)

--- a/test/test_relationship_models.py
+++ b/test/test_relationship_models.py
@@ -6,7 +6,6 @@ import pytz
 from neomodel import (StructuredNode, StructuredRel, Relationship, RelationshipTo,
                       StringProperty, DateTimeProperty, DeflateError)
 
-
 HOOKS_CALLED = {
     'pre_save': 0,
     'post_save': 0


### PR DESCRIPTION
# Changes
Initial work on rectifying issue 283, outlined [here](https://github.com/neo4j-contrib/neomodel/issues/283) and in more detail [here](https://github.com/aanastasiou/neomodelInheritanceTest).

A "class registry" has been added in `util.Database`. It is populated automatically by `core.NodeMeta.__new__` and subsequently used by `util.Database.cypher_objectaware_query` to properly instantiate query results to objects in a hierarchy.

This is **effected** by `match.QueryBuilder._execute` (which now uses `cypher_objectaware_query`) when the entity is instantiated **from** the database and **enforced** by `relationship_manager.RelationshipManager._check_node` when a connection between two entities is attempted to be established. The latter now tests for `issubclass` rather than `isinstance`.

To keep this functionality consistent, `relationship.StructuredRel.start_node` and `relationship.StructuredRel.end_node` had to also be modified so that they instantiate nodes of the correct type as inferred by the labels retrieved from the database (as opposed to simply looking at the type set when defining the model).

Entity specific `inflate` functions (For StructuredNode and StructuredRel) are still valid in case a node of specific class that is known at run-time needs to be instantiated.

# Open issues

1. The class registry is populated automatically, when classes are "created" at runtime. Consequently, the registry would be unaware of classes whose definition is perfectly alright **but have not been loaded yet** (i.e. not yet `import`ed).
    * This will raise `KeyError` on the class registry anyway but perhaps a more informative neomodel-specific exception is required here (?)
    * If this could be regarded as "expectable behaviour", it would be best if it is mentioned in the documentation

2. There is a corner case where a query might include labels that are associated with an entity in the database but not fully specified in the model (yet). This is similar to the first issue but also covers the case of "additional labels found" (as opposed to just "no matching labels found").
    * Should this raise an exception?
    * Does this warrant a "switch" parameter to turn on a "silent fail"? In this case, a list of results is returned that **could** contain plain simple `Node` objects for those results that could not be resolved.
    * Could as well appear in the documentation as a note or a warning.
