### PR TITLE
Respect db_property on model properties in get_or_create

### DIFF
--- a/neomodel/core.py
+++ b/neomodel/core.py
@@ -352,8 +352,9 @@ class StructuredNode(NodeBase):
         :rtype: tuple
         """
         query_params = dict(merge_params=merge_params)
-        n_merge = "n:{} {{{}}}".format(':'.join(cls.inherited_labels()),
-                                         ", ".join("{0}: params.create.{0}".format(p) for p in cls.__required_properties__))
+        n_merge = "n:{} {{{}}}".format(
+            ":".join(cls.inherited_labels()),
+            ", ".join("{0}: params.create.{0}".format(getattr(cls, p).db_property or p) for p in cls.__required_properties__))
         if relationship is None:
             # create "simple" unwind query
             query = "UNWIND {{merge_params}} as params\n MERGE ({})\n ".format(n_merge)

--- a/test/test_properties.py
+++ b/test/test_properties.py
@@ -195,6 +195,25 @@ def test_independent_property_name():
     x.delete()
 
 
+def test_independent_property_name_get_or_create():
+    class TestNode(StructuredNode):
+        uid = UniqueIdProperty()
+        name_ = StringProperty(db_property="name", required=True)
+
+    # create the node
+    TestNode.get_or_create({'uid': 123, 'name_': 'jim'})
+    # test that the node is retrieved correctly
+    x = TestNode.get_or_create({'uid': 123, 'name_': 'jim'})[0]
+
+    # check database property name on low level
+    results, meta = db.cypher_query("MATCH (n:TestNode) RETURN n")
+    assert results[0][0].properties['name'] == "jim"
+    assert 'name_' not in results[0][0].properties
+
+    # delete node afterwards
+    x.delete()
+
+
 def test_normal_property():
     class TestProperty(NormalProperty):
         def normalize(self, value):


### PR DESCRIPTION
When calling `get_or_create` on a node that already exists and has a property with `db_property` set, I would get the error `Cannot merge node using null property value for var_name`, which is now addressed in `core.py` by checking to see if `db_property` is set on the property.