### PR TITLE
Respect when db_property is set in install_labels

### DIFF
--- a/neomodel/core.py
+++ b/neomodel/core.py
@@ -84,22 +84,23 @@ def install_labels(cls, quiet=True, stdout=None):
         return
 
     for key, prop in cls.defined_properties(aliases=False, rels=False).items():
+        db_property = prop.db_property or key
         if prop.index:
             if not quiet:
                 stdout.write(' + Creating index {} on label {} for class {}.{}\n'.format(
-                    key, cls.__label__, cls.__module__, cls.__name__))
+                    db_property, cls.__label__, cls.__module__, cls.__name__))
 
             db.cypher_query("CREATE INDEX on :{}({}); ".format(
-                cls.__label__, key))
+                cls.__label__, db_property))
 
         elif prop.unique_index:
             if not quiet:
                 stdout.write(' + Creating unique constraint for {} on label {} for class {}.{}\n'.format(
-                    key, cls.__label__, cls.__module__, cls.__name__))
+                    db_property, cls.__label__, cls.__module__, cls.__name__))
 
             db.cypher_query("CREATE CONSTRAINT "
                             "on (n:{}) ASSERT n.{} IS UNIQUE; ".format(
-                cls.__label__, key))
+                cls.__label__, db_property))
 
 
 def install_all_labels(stdout=None):

--- a/test/test_label_install.py
+++ b/test/test_label_install.py
@@ -1,4 +1,9 @@
-from neomodel import config, StructuredNode, StringProperty, install_all_labels, install_labels
+from six import StringIO
+import pytest
+from neo4j.exceptions import DatabaseError
+from neomodel import (
+    config, StructuredNode, StringProperty, install_all_labels, install_labels,
+    UniqueIdProperty)
 from neomodel.core import db
 
 
@@ -33,3 +38,19 @@ def test_install_all():
     assert True
     # remove constraint for above test
     db.cypher_query("DROP CONSTRAINT on (n:NoConstraintsSetup) ASSERT n.name IS UNIQUE")
+
+
+def test_install_labels_db_property():
+    class SomeNode(StructuredNode):
+        id_ = UniqueIdProperty(db_property='id')
+    stdout = StringIO()
+    install_labels(SomeNode, quiet=False, stdout=stdout)
+    assert 'id' in stdout.getvalue()
+    assert 'id_' not in stdout.getvalue()
+    # make sure that the id_ constraint doesn't exist
+    with pytest.raises(DatabaseError) as exc_info:
+        db.cypher_query(
+            'DROP CONSTRAINT on (n:SomeNode) ASSERT n.id_ IS UNIQUE')
+    assert 'No such constraint' in exc_info.exconly()
+    # make sure the id constraint exists and can be removed
+    db.cypher_query('DROP CONSTRAINT on (n:SomeNode) ASSERT n.id IS UNIQUE')


### PR DESCRIPTION
Currently, `neomodel_install_labels` uses the wrong property name when a `UniqueIdProperty` has `db_property` set. This PR fixes that.

Reproducer:
```python
class ContainerBuilds(StructuredNode):
    id_ = UniqueIdProperty(db_property='id')
```
Then run `neomodel_install_labels` on the file. It will create the unique constraint on `id_` instead of `id`.