### PR TITLE
Ensure_connection only called when accessing the database, not when c…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ development.env
 .python-version
 .ropeproject
 \#*\#
+.eggs

--- a/neomodel/util.py
+++ b/neomodel/util.py
@@ -4,7 +4,6 @@ import sys
 import time
 import warnings
 from threading import local
-from functools import wraps
 
 from neo4j.v1 import GraphDatabase, basic_auth, CypherError, SessionError
 

--- a/neomodel/util.py
+++ b/neomodel/util.py
@@ -4,6 +4,7 @@ import sys
 import time
 import warnings
 from threading import local
+from functools import wraps
 
 from neo4j.v1 import GraphDatabase, basic_auth, CypherError, SessionError
 
@@ -21,8 +22,14 @@ logger = logging.getLogger(__name__)
 # make sure the connection url has been set prior to executing the wrapped function
 def ensure_connection(func):
     def wrapper(self, *args, **kwargs):
-        if not self.url:
-            self.set_connection(config.DATABASE_URL)
+        # Sort out where to find url
+        if hasattr(self, 'db'):
+            _db = self.db
+        else:
+            _db = self
+
+        if not _db.url:
+            _db.set_connection(config.DATABASE_URL)
         return func(self, *args, **kwargs)
 
     return wrapper
@@ -62,7 +69,6 @@ class Database(local):
         self._active_transaction = None
 
     @property
-    @ensure_connection
     def transaction(self):
         return TransactionProxy(self)
 
@@ -127,6 +133,7 @@ class TransactionProxy(object):
     def __init__(self, db):
         self.db = db
 
+    @ensure_connection
     def __enter__(self):
         self.db.begin()
         return self


### PR DESCRIPTION
…onstructing the transaction decorator - see #287 

This change is to allow neomodel-enabled apps to start when a database is not present, and it will only throw a connection error when attempting to access the database. This removes the need for separate error handling when the database starts after the app.