### PR TITLE
Add missing parameter in Relationships documentation

### DIFF
--- a/doc/source/relationships.rst
+++ b/doc/source/relationships.rst
@@ -20,10 +20,10 @@ It's possible to (softly) enforce cardinality restrictions on your relationships
 Remember this needs to be declared on both sides of the definition::
 
     class Person(StructuredNode):
-        car = RelationshipTo('Car', 'CAR', cardinality=One)
+        car = RelationshipTo('Car', 'OWNS', cardinality=One)
 
     class Car(StructuredNode):
-        owner = RelationshipFrom('Person', 'CAR', cardinality=One)
+        owner = RelationshipFrom('Person', 'OWNS', cardinality=One)
 
 The following cardinality classes are available:
 

--- a/doc/source/relationships.rst
+++ b/doc/source/relationships.rst
@@ -23,7 +23,7 @@ Remember this needs to be declared on both sides of the definition::
         car = RelationshipTo('Car', 'CAR', cardinality=One)
 
     class Car(StructuredNode):
-        owner = RelationshipFrom('Person', cardinality=One)
+        owner = RelationshipFrom('Person', 'CAR', cardinality=One)
 
 The following cardinality classes are available:
 


### PR DESCRIPTION
Using the documentation as is provides the error `TypeError: RelationshipFrom() takes at least 2 arguments (2 given)`.