### PR TITLE
Add the "first" and "first_or_none" methods on the NodeSet class

### DIFF
--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -98,6 +98,12 @@ Using the '.nodes' class property::
     # Will return None unless bob exists
     someone = Person.nodes.get_or_none(name='bob')
 
+    # Will return the first Person node with the name bob. This raises Person.DoesNotExist if there's no match.
+    someone = Person.nodes.first(name='bob')
+
+    # Will return the first Person node with the name bob or None if there's no match
+    someone = Person.nodes.first_or_none(name='bob')
+
     # Return set of nodes
     people = Person.nodes.filter(age__gt=3)
 

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -68,6 +68,22 @@ def test_get_and_get_or_none():
     assert n is None
 
 
+def test_first_and_first_or_none():
+    u = User(email='matt@test.com', age=24)
+    assert u.save()
+    u2 = User(email='tbrady@test.com', age=40)
+    assert u2.save()
+    tbrady = User.nodes.order_by('-age').first()
+    assert tbrady.email == 'tbrady@test.com'
+    assert tbrady.age == 40
+
+    tbrady = User.nodes.order_by('-age').first_or_none()
+    assert tbrady.email == 'tbrady@test.com'
+
+    n = User.nodes.first_or_none(email='matt@nothere.com')
+    assert n is None
+
+
 def test_save_to_model():
     u = User(email='jim@test.com', age=3)
     assert u.save()


### PR DESCRIPTION
I'm used to SQLAlchemy and they have a handy [first](http://docs.sqlalchemy.org/en/latest/orm/query.html#sqlalchemy.orm.query.Query.first) method. This PR implements something very similar to that but instead matches the behavior of `get` and `get_or_none` for consistency.