### PR TITLE
Don't raise a cardinality exception when connecting an already connected node

### DIFF
--- a/neomodel/cardinality.py
+++ b/neomodel/cardinality.py
@@ -36,7 +36,7 @@ class ZeroOrOne(RelationshipManager):
         :type: dict
         :return: True / rel instance
         """
-        if len(self):
+        if len(self) and node not in self:
             raise AttemptedCardinalityViolation(
                     "Node already has {0} can't connect more".format(self))
         else:
@@ -124,7 +124,7 @@ class One(RelationshipManager):
         """
         if not hasattr(self.source, 'id'):
             raise ValueError("Node has not been saved cannot connect!")
-        if len(self):
+        if len(self) and node not in self:
             raise AttemptedCardinalityViolation(
                 "Node already has one relationship"
             )

--- a/test/test_cardinality.py
+++ b/test/test_cardinality.py
@@ -92,7 +92,7 @@ def test_cardinality_one():
     m.toothbrush.connect(b)
     assert m.toothbrush.single().name == 'Jim'
 
-    x = ToothBrush(name='Jim').save
+    x = ToothBrush(name='Jim').save()
     with raises(AttemptedCardinalityViolation):
         m.toothbrush.connect(x)
 

--- a/test/test_cardinality.py
+++ b/test/test_cardinality.py
@@ -54,6 +54,10 @@ def test_cardinality_zero_or_one():
     assert len(m.driver.all()) == 1
     assert m.driver.single().version == 1
 
+    # Make sure an exception is not raised when connect is called with an
+    # already connected node
+    m.driver.connect(h)
+
     j = ScrewDriver(version=2).save()
     with raises(AttemptedCardinalityViolation):
         m.driver.connect(j)
@@ -91,6 +95,10 @@ def test_cardinality_one():
     b = ToothBrush(name='Jim').save()
     m.toothbrush.connect(b)
     assert m.toothbrush.single().name == 'Jim'
+
+    # Make sure an exception is not raised when connect is called with an
+    # already connected node
+    m.toothbrush.connect(b)
 
     x = ToothBrush(name='Jim').save()
     with raises(AttemptedCardinalityViolation):


### PR DESCRIPTION
I'd like to start using cardinality in my project but my existing code that imports data into Neo4j attempts to connect nodes without checking if the relationship already exists, which works just fine when cardinality is not used. I'd like to continue using this approach, so this PR will check to see if the node being connected is already connected before raising an `AttemptedCardinalityViolation` exception.