### PR TITLE
Add the "disconnect_all" and "replace" methods on relationship properties

### DIFF
--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -135,3 +135,7 @@ Working with relationships::
 
     # Remove all of Jim's country relationships
     jim.country.disconnect_all()
+
+    jim.country.connect(usa)
+    # Replace Jim's country relationship with a new one
+    jim.country.replace(germany)

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -126,4 +126,12 @@ Working with relationships::
     # Find people called 'Jim' in germany
     germany.inhabitant.search(name='Jim')
 
+    # Remove Jim's country relationship with Germany
     jim.country.disconnect(germany)
+
+    usa = Country(code='US').save()
+    jim.country.connect(usa)
+    jim.country.connect(germany)
+
+    # Remove all of Jim's country relationships
+    jim.country.disconnect_all()

--- a/neomodel/cardinality.py
+++ b/neomodel/cardinality.py
@@ -114,6 +114,11 @@ class One(RelationshipManager):
             "Cardinality one, cannot disconnect use reconnect."
         )
 
+    def disconnect_all(self):
+        raise AttemptedCardinalityViolation(
+            "Cardinality one, cannot disconnect_all use reconnect."
+        )
+
     def connect(self, node, properties=None):
         """
         Connect a node

--- a/neomodel/relationship_manager.py
+++ b/neomodel/relationship_manager.py
@@ -209,6 +209,18 @@ class RelationshipManager(object):
         self.source.cypher(q, {'them': node.id})
 
     @check_source
+    def disconnect_all(self):
+        """
+        Disconnect all nodes
+
+        :return:
+        """
+        rhs = 'b:' + self.definition['node_class'].__label__
+        rel = _rel_helper(lhs='a', rhs=rhs, ident='r', **self.definition)
+        q = "MATCH (a) WHERE id(a)={self} MATCH " + rel + " DELETE r"
+        self.source.cypher(q)
+
+    @check_source
     def _new_traversal(self):
         return Traversal(self.source, self.name, self.definition)
 

--- a/neomodel/relationship_manager.py
+++ b/neomodel/relationship_manager.py
@@ -108,6 +108,19 @@ class RelationshipManager(object):
         return rel_instance
 
     @check_source
+    def replace(self, node, properties=None):
+        """
+        Disconnect all existing nodes and connect the supplied node
+
+        :param node:
+        :param properties: for the new relationship
+        :type: dict
+        :return:
+        """
+        self.disconnect_all()
+        self.connect(node, properties)
+
+    @check_source
     def relationship(self, node):
         """
         Retrieve the relationship object for this first relationship between self and node.
@@ -217,7 +230,7 @@ class RelationshipManager(object):
         """
         rhs = 'b:' + self.definition['node_class'].__label__
         rel = _rel_helper(lhs='a', rhs=rhs, ident='r', **self.definition)
-        q = "MATCH (a) WHERE id(a)={self} MATCH " + rel + " DELETE r"
+        q = 'MATCH (a) WHERE id(a)={self} MATCH ' + rel + ' DELETE r'
         self.source.cypher(q)
 
     @check_source

--- a/test/test_cardinality.py
+++ b/test/test_cardinality.py
@@ -43,6 +43,13 @@ def test_cardinality_zero_or_more():
     assert m.dryers.all() == []
     assert m.dryers.single() is None
 
+    h2 = HairDryer(version=2).save()
+    m.dryers.connect(h)
+    m.dryers.connect(h2)
+    m.dryers.disconnect_all()
+    assert m.dryers.all() == []
+    assert m.dryers.single() is None
+
 
 def test_cardinality_zero_or_one():
     m = Monkey(name='bob').save()

--- a/test/test_relationships.py
+++ b/test/test_relationships.py
@@ -143,6 +143,32 @@ def test_valid_reconnection():
     assert c.president.is_connected(pp)
 
 
+def test_valid_replace():
+    brady = Person(name='Tom Brady', age=40).save()
+    assert brady
+
+    gronk = Person(name='Rob Gronkowski', age=28).save()
+    assert gronk
+
+    colbert = Person(name='Stephen Colbert', age=53).save()
+    assert colbert
+
+    hanks = Person(name='Tom Hanks', age=61).save()
+    assert hanks
+
+    brady.knows.connect(gronk)
+    brady.knows.connect(colbert)
+    assert len(brady.knows) == 2
+    assert brady.knows.is_connected(gronk)
+    assert brady.knows.is_connected(colbert)
+
+    brady.knows.replace(hanks)
+    assert len(brady.knows) == 1
+    assert brady.knows.is_connected(hanks)
+    assert not brady.knows.is_connected(gronk)
+    assert not brady.knows.is_connected(colbert)
+
+
 def test_props_relationship():
     u = Person(name='Mar', age=20).save()
     assert u


### PR DESCRIPTION
My project that uses neomodel requires replacing all existing relationships with a new one. I found myself doing this by looping through all the connected nodes and disconnect the relationships individually. This was repetitive across the code base and inefficient. This PR adds the ability to replace all relationships of a specific type with a new one. It also adds the ability to remove all existing relationships of a specific type.