### PR TITLE
Lower the required pytz version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     scripts=['scripts/neomodel_install_labels', 'scripts/neomodel_remove_labels'],
     setup_requires=['pytest-runner'] if any(x in ('pytest', 'test') for x in sys.argv) else [],
     tests_require=['pytest'],
-    install_requires=['neo4j-driver==1.5.2', 'pytz>=2018.3'],
+    install_requires=['neo4j-driver==1.5.2', 'pytz>=2016.10'],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         'Intended Audience :: Developers',


### PR DESCRIPTION
neomodel is packaged in EPEL (Extra Packages for Enterprise Linux) for EL7 (RHEL 7/CentOS 7) and the latest version of pytz available on EL7 is 2016.10. Having the version of pytz too high makes it so that neomodel can't be packaged for EL7 and current versions of Fedora (Fedora uses version 2017.2).