### PR TITLE
Explicit write transaction mode

### DIFF
--- a/doc/source/transactions.rst
+++ b/doc/source/transactions.rst
@@ -1,6 +1,6 @@
 Transactions
 ------------
-transactions can be used via a context manager::
+Transactions can be used via a context manager::
 
     from neomodel import db
 
@@ -26,9 +26,19 @@ or manually::
         db.rollback()
 
 Transactions are local to the thread as is the `db` object (see `threading.local`).
-If your using celery or another task scheduler its advised to wrap each task within a transaction::
+If you're using celery or another task scheduler it's advised to wrap each task within a transaction::
 
     @task
     @db.transaction  # comes after the task decorator
     def send_email(user):
         ...
+
+Transactions can also be designated as *write transactions*.
+Marking as a write transaction may not matter on a single-instance Neo4J, but is vital in a Neo4J causal cluster where writes must be sent to the leader node.
+For performance purposes, this should be limited to transactions that write/delete data, or any situation where talking to the leader node is essential::
+
+    @db.write_transaction
+    def update_user_name(uid, name):
+        user = Person.nodes.filter(uid=uid)[0]
+        user.name = name
+        user.save()


### PR DESCRIPTION
Causal clustering has a leader and multiple followers. Only leader can be written to.

Initiating a transaction with `@db.transaction` doesn't seem to allow the specifying of a transactionality type (Bolt is READ or WRITE), thus it's possible that the `bolt+routing` protocol could route a write transaction to a follower.

This PR allows the developer to choose `@db.write_transaction`, which will set `access_mode` to `"WRITE"`, directing Bolt to the leader of a causal cluster. It defaults to the previous behaviour to avoids backwards compatibility issues.