### PR TITLE
Support filtering on properties that end with an underscore

### DIFF
--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -135,7 +135,7 @@ def process_filter_args(cls, kwargs):
 
     for key, value in kwargs.items():
         if '__' in key:
-            prop, operator = key.split('__')
+            prop, operator = key.rsplit('__')
             operator = OPERATOR_TABLE[operator]
         else:
             prop = key

--- a/test/test_match_api.py
+++ b/test/test_match_api.py
@@ -25,6 +25,7 @@ class Coffee(StructuredNode):
     name = StringProperty(unique_index=True)
     price = IntegerProperty()
     suppliers = RelationshipFrom(Supplier, 'COFFEE SUPPLIERS', model=SupplierRel)
+    id_ = IntegerProperty()
 
 
 def test_filter_exclude_via_labels():
@@ -220,10 +221,10 @@ def test_extra_filters():
     for c in Coffee.nodes:
         c.delete()
 
-    c1 = Coffee(name="Icelands finest", price=5).save()
-    c2 = Coffee(name="Britains finest", price=10).save()
-    c3 = Coffee(name="Japans finest", price=35).save()
-    c4 = Coffee(name="US extra-fine", price=None).save()
+    c1 = Coffee(name="Icelands finest", price=5, id_=1).save()
+    c2 = Coffee(name="Britains finest", price=10, id_=2).save()
+    c3 = Coffee(name="Japans finest", price=35, id_=3).save()
+    c4 = Coffee(name="US extra-fine", price=None, id_=4).save()
 
     coffees_5_10 = Coffee.nodes.filter(price__in=[10, 5]).all()
     assert len(coffees_5_10) == 2, "unexpected number of results"
@@ -239,6 +240,11 @@ def test_extra_filters():
     unpriced_coffees = Coffee.nodes.filter(price__isnull=True).all()
     assert len(unpriced_coffees) == 1, "unexpected number of results"
     assert c4 in unpriced_coffees, "doesnt contain unpriced coffee"
+
+    coffees_with_id_gte_3 = Coffee.nodes.filter(id___gte=3).all()
+    assert len(coffees_with_id_gte_3) == 2, "unexpected number of results"
+    assert c3 in coffees_with_id_gte_3
+    assert c4 in coffees_with_id_gte_3
 
 
 def test_traversal_definition_keys_are_valid():


### PR DESCRIPTION
Some of my structured nodes have properties that end with an underscore to not override default methods like `hash`. I ran into an issue when I tried to filter on those properties. This PR corrects that.