### PR TITLE
Empty filter bug

### DIFF
--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -625,8 +625,7 @@ class NodeSet(BaseSet):
         :param kwargs: filter parameters see syntax for the filter method
         :return: self
         """
-        if args or kwargs:
-            self.q_filters = Q(self.q_filters & ~Q(*args, **kwargs))
+        self.q_filters = Q(self.q_filters & ~Q(*args, **kwargs))
         return self
 
     def has(self, **kwargs):

--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -625,7 +625,8 @@ class NodeSet(BaseSet):
         :param kwargs: filter parameters see syntax for the filter method
         :return: self
         """
-        self.q_filters = Q(self.q_filters & ~Q(*args, **kwargs))
+        if args or kwargs:
+            self.q_filters = Q(self.q_filters & ~Q(*args, **kwargs))
         return self
 
     def has(self, **kwargs):

--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -614,8 +614,8 @@ class NodeSet(BaseSet):
 
         :return: self
         """
-
-        self.q_filters = Q(self.q_filters & Q(*args, **kwargs))
+        if kwargs:
+            self.q_filters = Q(self.q_filters & Q(*args, **kwargs))
         return self
 
     def exclude(self, *args, **kwargs):

--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -614,7 +614,7 @@ class NodeSet(BaseSet):
 
         :return: self
         """
-        if kwargs:
+        if args or kwargs:
             self.q_filters = Q(self.q_filters & Q(*args, **kwargs))
         return self
 

--- a/test/test_match_api.py
+++ b/test/test_match_api.py
@@ -266,6 +266,38 @@ def test_traversal_definition_keys_are_valid():
     )
 
 
+def test_empty_filters():
+    """Test this case:
+        ```
+            SomeModel.nodes.filter().filter(Q(arg1=val1)).all()
+            SomeModel.nodes.exclude().exclude(Q(arg1=val1)).all()
+            SomeModel.nodes.filter().filter(arg1=val1).all()
+       ```
+       In django_rest_framework filter uses such as lazy function and
+       ``get_queryset`` function in ``GenericAPIView`` should returns
+       ``NodeSet`` object.
+    """
+
+    for c in Coffee.nodes:
+        c.delete()
+
+    c1 = Coffee(name="Super", price=5, id_=1).save()
+    c2 = Coffee(name="Puper", price=10, id_=2).save()
+
+    empty_filter = Coffee.nodes.filter()
+
+    all_coffees = empty_filter.all()
+    assert len(all_coffees) == 2, "unexpected number of results"
+
+    filter_empty_filter = empty_filter.filter(price=5)
+    assert len(filter_empty_filter.all()) == 1, "unexpected number of results"
+    assert c1 in filter_empty_filter.all(), "doesnt contain c1 in ``filter_empty_filter``"
+
+    filter_q_empty_filter = empty_filter.filter(Q(price=5))
+    assert len(filter_empty_filter.all()) == 1, "unexpected number of results"
+    assert c1 in filter_empty_filter.all(), "doesnt contain c1 in ``filter_empty_filter``"
+
+
 def test_q_filters():
 
     for c in Coffee.nodes:


### PR DESCRIPTION
If you're trying do this
```
SomeModel.nodes.filter().filter(arg1=val1).all()
```
neomodel throws exception like this
```
MATCH (somemodel:SomeModel) WHERE AND somemodel.arg1={arg1_1} RETURN ....
```
I fixed it. Sorry for my bad english