### PR TITLE
Testing includes now neo4j 3.4+3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,42 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7-dev"
+  - "pypy"
+  - "pypy3.5"
 env:
-  - NEO4J_VERSION="3.0.10"
-  - NEO4J_VERSION="3.1.7"
-  - NEO4J_VERSION="3.2.9"
-  - NEO4J_VERSION="3.3.3"
+  #- NEO4J_VERSION="3.0.10"  # unsupported by neo4j.com (DEC18)
+  #- NEO4J_VERSION="3.1.7"   # unsupported by neo4j.com (DEC18)
+  - NEO4J_VERSION="3.2.13"
+  - NEO4J_VERSION="3.3.9"
+  - NEO4J_VERSION="3.4.10"
+  - NEO4J_VERSION="3.5.0"
+matrix:
+  exclude:  # reducing the testing matrix a bit.
+    - python: "2.7"
+      env: NEO4J_VERSION=3.5.0
+    - python: "pypy"
+      env: NEO4J_VERSION=3.4.10
+    - python: "pypy"
+      env: NEO4J_VERSION=3.5.0
+    - python: "3.4"
+      env: NEO4J_VERSION=3.4.10
+    - python: "3.4"
+      env: NEO4J_VERSION=3.5.0
+    - python: "pypy3.5"
+      env: NEO4J_VERSION=3.2.13
+    - python: "pypy3.5"
+      env: NEO4J_VERSION=3.3.9
+
 install:
   - sudo apt-get update && sudo apt-get install oracle-java8-installer
   - curl -L http://dist.neo4j.org/neo4j-community-$NEO4J_VERSION-unix.tar.gz | tar xz
+  - pip install tox-travis
 before_script:
   - JAVA_HOME=/usr/lib/jvm/java-8-oracle neo4j-community-$NEO4J_VERSION/bin/neo4j start
   - sleep 10
-script: "python setup.py test"
+script:
+  - tox
+notifications:
+  email: false
+

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+UNNUMBERED
+ * Updated neo4j-driver package to include 1.7 versions, refactored deprecated use of neo4j.v1 in utils.py - J. Berends
+ * Refactor testing suite to include neo4j 3.4 and 3.5. - J. Berends
+
 Version 3.3.0 2018-10-04
  * Added support for Q() in filter and exclude (#360) - Juan H. Hidalgo
  * Added  object docs and examples - Juan H. Hidalgo
@@ -6,12 +10,12 @@ Version 3.3.0 2018-10-04
  * Closed #361 Nodes connected with two or more relationships - Mardanov Timur Rustemovich
  * Exclude method fixed - Mardanov Timur Rustemovich
  * Filter with OR fixed - Mardanov Timur Rustemovich
- * Resolved #283, improved object resolution of cypher_query so that it 
-   resolves objects even if they are nested within lists. Overall 
+ * Resolved #283, improved object resolution of cypher_query so that it
+   resolves objects even if they are nested within lists. Overall
    documentation edits - Athanasios Anastasiou
-   
+
 Version 3.2.9 2018-07-04
- * Add check for wiping db on test run - Athanasios 
+ * Add check for wiping db on test run - Athanasios
  * Correct function name in doc string - Henry Jordan
  * Support filtering on properties that end with a hash (#348) - mprahl
  * Support neo4j-driver v1.6.0 (#347) - mprahl

--- a/README.rst
+++ b/README.rst
@@ -31,10 +31,6 @@ An Object Graph Mapper (OGM) for the neo4j_ graph database, built on the awesome
     :target: https://secure.travis-ci.org/neo4j-contrib/neomodel/
     :alt: Build Status
 
-.. image:: https://coveralls.io/repos/github/jberends/neomodel/badge.svg?branch=master
-    :target: https://coveralls.io/github/jberends/neomodel?branch=master
-    :alt: Coverage Status
-
 .. image:: https://readthedocs.org/projects/neomodel/badge/?version=latest
     :alt: Documentation Status
     :scale: 100%

--- a/README.rst
+++ b/README.rst
@@ -15,8 +15,25 @@ An Object Graph Mapper (OGM) for the neo4j_ graph database, built on the awesome
 .. _neo4j: https://neo4j.com/
 .. _neo4j_driver: https://github.com/neo4j/neo4j-python-driver
 
+.. image:: https://img.shields.io/pypi/v/neomodel.svg
+    :target: https://pypi.python.org/pypi/neomodel
+    :alt: Version
+
+.. image:: https://img.shields.io/badge/neo4j-3.0%20%7C%203.1%20%7C%203.2%20%7C%203.3%20%7C%203.4%20%7C%203.5-blue.svg
+    :target: https://neo4j.com
+    :alt: Supported Neo4j versions
+
+.. image:: https://img.shields.io/pypi/pyversions/neomodel.svg
+    :target: https://pypi.python.org/pypi/neomodel
+    :alt: Supported Python Versions
+
 .. image:: https://secure.travis-ci.org/neo4j-contrib/neomodel.png
     :target: https://secure.travis-ci.org/neo4j-contrib/neomodel/
+    :alt: Build Status
+
+.. image:: https://coveralls.io/repos/github/jberends/neomodel/badge.svg?branch=master
+    :target: https://coveralls.io/github/jberends/neomodel?branch=master
+    :alt: Coverage Status
 
 .. image:: https://readthedocs.org/projects/neomodel/badge/?version=latest
     :alt: Documentation Status
@@ -34,7 +51,7 @@ Requirements
 ============
 
 - Python 2.7, 3.4+
-- neo4j 3.0, 3.1, 3.2, 3.3
+- neo4j 3.0, 3.1, 3.2, 3.3, 3.4, 3.5
 
 Installation
 ============
@@ -50,13 +67,13 @@ To install from github::
 Upgrading 2.x to 3.x
 ====================
 
- * Now utilises neo4j_driver as the backend which uses bolt so neo4j 3 is required
- * Connection now set through config.DATABASE_URL (see getting started docs)
- * The deprecated category() method on StructuredNode has been removed
- * The deprecated index property on StructuredNode has been removed
- * The streaming=True flag is now irrelevant with bolt and produces a deprecation warning
+ * Now utilises `neo4j_driver` as the backend which uses bolt so neo4j 3+ is required
+ * Connection now set through `config.DATABASE_URL` (see getting started docs)
+ * The deprecated category() method on `StructuredNode` has been removed
+ * The deprecated index property on `StructuredNode` has been removed
+ * The `streaming=True` flag is now irrelevant with bolt and produces a deprecation warning
  * Batch operations must now be wrapped in a transaction in order to be atomic
- * Indexing NodeSets returns a single node now as opposed to a list
+ * Indexing `NodeSets` returns a single node now as opposed to a list
 
 Contributing
 ============
@@ -79,7 +96,7 @@ Setup a virtual environment, install neomodel for development and run the test s
 
 If your running a neo4j database for the first time the test suite will set the password to 'test'.
 
-If you have ``docker-compose`` installed, you can run the test suite against all supported Python
+If you have `docker-compose` installed, you can run the test suite against all supported Python
 interpreters and neo4j versions::
 
     # in the project's root folder:

--- a/neomodel/cardinality.py
+++ b/neomodel/cardinality.py
@@ -3,7 +3,7 @@ from neomodel.exceptions import (
 )
 from neomodel.relationship_manager import (
     RelationshipManager, ZeroOrMore
-)  #noqa: F401
+)  # noqa: F401
 
 
 class ZeroOrOne(RelationshipManager):
@@ -38,7 +38,7 @@ class ZeroOrOne(RelationshipManager):
         """
         if len(self):
             raise AttemptedCardinalityViolation(
-                    "Node already has {0} can't connect more".format(self))
+                "Node already has {0} can't connect more".format(self))
         else:
             return super(ZeroOrOne, self).connect(node, properties)
 

--- a/neomodel/core.py
+++ b/neomodel/core.py
@@ -172,7 +172,7 @@ class NodeMeta(type):
             if config.AUTO_INSTALL_LABELS:
                 install_labels(cls)
             db._NODE_CLASS_REGISTRY[frozenset(cls.inherited_labels())] = cls
-            
+
         return cls
 
 
@@ -255,7 +255,8 @@ class StructuredNode(NodeBase):
         query_params = dict(merge_params=merge_params)
         n_merge = "n:{} {{{}}}".format(
             ":".join(cls.inherited_labels()),
-            ", ".join("{0}: params.create.{0}".format(getattr(cls, p).db_property or p) for p in cls.__required_properties__))
+            ", ".join(
+                "{0}: params.create.{0}".format(getattr(cls, p).db_property or p) for p in cls.__required_properties__))
         if relationship is None:
             # create "simple" unwind query
             query = "UNWIND {{merge_params}} as params\n MERGE ({})\n ".format(n_merge)
@@ -292,7 +293,7 @@ class StructuredNode(NodeBase):
     @classmethod
     def category(cls):
         raise NotImplementedError("Category was deprecated and has now been removed, "
-            "the functionality is now achieved using the {}.nodes attribute".format(cls.__name__))
+                                  "the functionality is now achieved using the {}.nodes attribute".format(cls.__name__))
 
     @classmethod
     def create(cls, *props, **kwargs):
@@ -494,7 +495,7 @@ class StructuredNode(NodeBase):
         self._pre_action_check('refresh')
         if hasattr(self, 'id'):
             request = self.cypher("MATCH (n) WHERE id(n)={self}"
-                                            " RETURN n")[0]
+                                  " RETURN n")[0]
             if not request or not request[0]:
                 raise self.__class__.DoesNotExist("Can't refresh non existent node")
             node = self.inflate(request[0][0])

--- a/neomodel/hooks.py
+++ b/neomodel/hooks.py
@@ -14,4 +14,5 @@ def hooks(fn):
         val = fn(self)
         _exec_hook('post_' + fn_name, self)
         return val
+
     return hooked

--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -1,11 +1,12 @@
-from .core import StructuredNode, db
-from .properties import AliasProperty
-from .exceptions import MultipleNodesReturned
-from .match_q import Q, QBase
 import inspect
 import re
-OUTGOING, INCOMING, EITHER = 1, -1, 0
 
+from .core import StructuredNode, db
+from .exceptions import MultipleNodesReturned
+from .match_q import Q, QBase
+from .properties import AliasProperty
+
+OUTGOING, INCOMING, EITHER = 1, -1, 0
 
 # basestring python 3.x fallback
 try:
@@ -442,16 +443,16 @@ class QueryBuilder(object):
 
     def _execute(self):
         query = self.build_query()
-        results, _ = db.cypher_query(query, self._query_params, resolve_objects=True)            
-        # The following is not as elegant as it could be but had to be copied from the 
+        results, _ = db.cypher_query(query, self._query_params, resolve_objects=True)
+        # The following is not as elegant as it could be but had to be copied from the
         # version prior to cypher_query with the resolve_objects capability.
-        # It seems that certain calls are only supposed to be focusing to the first 
+        # It seems that certain calls are only supposed to be focusing to the first
         # result item returned (?)
         if results:
             return [n[0] for n in results]
         return []
-        
-        
+
+
 class BaseSet(object):
     """
     Base class for all node sets.
@@ -511,6 +512,7 @@ class NodeSet(BaseSet):
     """
     A class representing as set of nodes matching common query parameters
     """
+
     def __init__(self, source):
         self.source = source  # could be a Traverse object or a node class
         if isinstance(source, Traversal):
@@ -716,7 +718,7 @@ class Traversal(BaseSet):
         if invalid_keys:
             raise ValueError(
                 'Unallowed keys in Traversal definition: {invalid_keys}'
-                .format(invalid_keys=invalid_keys)
+                    .format(invalid_keys=invalid_keys)
             )
 
         self.definition = definition

--- a/neomodel/properties.py
+++ b/neomodel/properties.py
@@ -1,8 +1,8 @@
 import functools
 import json
+import re
 import sys
 import types
-import re
 import uuid
 import warnings
 from datetime import date, datetime
@@ -12,7 +12,6 @@ import pytz
 from neomodel import config
 from neomodel.exceptions import InflateError, DeflateError, RequiredProperty
 
-
 if sys.version_info >= (3, 0):
     unicode = str
 
@@ -20,6 +19,7 @@ if sys.version_info >= (3, 0):
 def display_for(key):
     def display_choice(self):
         return getattr(self.__class__, key).choices[getattr(self, key)]
+
     return display_choice
 
 
@@ -233,6 +233,8 @@ else:
         def __init__(self, *args, **kwargs):
             _warn_NormalProperty_renamed()
             super(NormalProperty, self).__init__(*args, **kwargs)
+
+
 ##
 
 
@@ -289,6 +291,7 @@ class StringProperty(NormalizedProperty):
                     value ``None`` is used, any string is valid.
     :type choices: Any type that can be used to initiate a :class:`dict`.
     """
+
     def __init__(self, choices=None, **kwargs):
         super(StringProperty, self).__init__(**kwargs)
 
@@ -482,6 +485,7 @@ class JSONProperty(Property):
 
     The structure will be inflated when a node is retrieved.
     """
+
     def __init__(self, *args, **kwargs):
         super(JSONProperty, self).__init__(*args, **kwargs)
 
@@ -498,6 +502,7 @@ class AliasProperty(property, Property):
     """
     Alias another existing property
     """
+
     def __init__(self, to=None):
         """
         Create new alias
@@ -531,6 +536,7 @@ class UniqueIdProperty(Property):
     """
     A unique identifier, a randomly generated uid (uuid4) with a unique index
     """
+
     def __init__(self, **kwargs):
         for item in ['required', 'unique_index', 'index', 'default']:
             if item in kwargs:

--- a/neomodel/relationship.py
+++ b/neomodel/relationship.py
@@ -1,7 +1,7 @@
-from .properties import Property, PropertyManager
 from .core import db
-from .util import deprecated
 from .hooks import hooks
+from .properties import Property, PropertyManager
+from .util import deprecated
 
 
 class RelationshipMeta(type):
@@ -27,6 +27,7 @@ class StructuredRel(StructuredRelBase):
     """
     Base class for relationship objects
     """
+
     def __init__(self, *args, **kwargs):
         super(StructuredRel, self).__init__(*args, **kwargs)
 
@@ -61,8 +62,8 @@ class StructuredRel(StructuredRelBase):
         return db.cypher_query("MATCH (aNode) "
                                "WHERE id(aNode)={nodeid} "
                                "RETURN aNode".format(nodeid=self._start_node_id),
-                               resolve_objects = True)[0][0][0]
-      
+                               resolve_objects=True)[0][0][0]
+
     def end_node(self):
         """
         Get end node
@@ -72,7 +73,7 @@ class StructuredRel(StructuredRelBase):
         return db.cypher_query("MATCH (aNode) "
                                "WHERE id(aNode)={nodeid} "
                                "RETURN aNode".format(nodeid=self._end_node_id),
-                               resolve_objects = True)[0][0][0]
+                               resolve_objects=True)[0][0][0]
 
     @classmethod
     def inflate(cls, rel):

--- a/neomodel/relationship_manager.py
+++ b/neomodel/relationship_manager.py
@@ -1,11 +1,11 @@
-import sys
 import functools
+import sys
 from importlib import import_module
+
 from .exceptions import NotConnected
-from .util import deprecated, _get_node_properties
 from .match import OUTGOING, INCOMING, EITHER, _rel_helper, Traversal, NodeSet
 from .relationship import StructuredRel
-
+from .util import deprecated, _get_node_properties
 
 # basestring python 3.x fallback
 try:
@@ -22,6 +22,7 @@ def check_source(fn):
     def checker(self, *args, **kwargs):
         self.source._pre_action_check(self.name + '.' + fn_name)
         return fn(self, *args, **kwargs)
+
     return checker
 
 
@@ -31,6 +32,7 @@ class RelationshipManager(object):
 
     I.e the 'friends' object in  `user.friends.all()`
     """
+
     def __init__(self, source, key, definition):
         self.source = source
         self.source_class = source.__class__

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@ addopts = test --strict
 
 [aliases]
 test = pytest
+
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,9 @@ setup(
     scripts=['scripts/neomodel_install_labels', 'scripts/neomodel_remove_labels'],
     setup_requires=['pytest-runner'] if any(x in ('pytest', 'test') for x in sys.argv) else [],
     tests_require=['pytest'],
-    install_requires=['neo4j-driver>=1.5.2, <1.7.0', 'pytz>=2016.10'],
+    install_requires=['neo4j-driver>=1.5.2, <1.7.0;python_version<="2.7"',
+                      'neo4j;python_version>="3.4"',
+                      'pytz>=2016.10'],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         'Intended Audience :: Developers',

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,47 +1,55 @@
 from __future__ import print_function
-import warnings
+
 import os
-import sys
+import warnings
+
+from neo4j.v1 import CypherError
 
 from neomodel import config, db, clear_neo4j_database, change_neo4j_password
-from neo4j.v1 import CypherError
 
 
 def pytest_addoption(parser):
     """
     Adds the command line option --resetdb.
-    
-    :param parser: The parser object. Please see <https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_addoption>`_
-    :type Parser object: For more information please see <https://docs.pytest.org/en/latest/reference.html#_pytest.config.Parser>`_
+
+    :param parser: The parser object.
+                   Please see <https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_addoption>`_
+    :type Parser object: For more information please
+                         see <https://docs.pytest.org/en/latest/reference.html#_pytest.config.Parser>`_
     """
-    parser.addoption("--resetdb", action="store_true", help = "Ensures that the database is clear prior to running tests for neomodel", default=False)
-    
+    parser.addoption("--resetdb", action="store_true",
+                     help="Ensures that the database is clear prior to running tests for neomodel", default=False)
+
+
 def pytest_sessionstart(session):
     """
     Provides initial connection to the database and sets up the rest of the test suite
-    
-    :param session: The session object. Please see <https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_sessionstart>`_
+
+    :param session: The session object.
+                    Please see <https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_sessionstart>`_
     :type Session object: For more information please see <https://docs.pytest.org/en/latest/reference.html#session>`_
     """
-    
+
     warnings.simplefilter('default')
-    
+
     config.DATABASE_URL = os.environ.get('NEO4J_BOLT_URL', 'bolt://neo4j:neo4j@localhost:7687')
     config.AUTO_INSTALL_LABELS = True
-    
+
     try:
         # Clear the database if required
         database_is_populated, _ = db.cypher_query("MATCH (a) return count(a)>0 as database_is_populated")
         if database_is_populated[0][0] and not session.config.getoption("resetdb"):
-            raise SystemError("Please note: The database seems to be populated.\n\tEither delete all nodes and edges manually, or set the --resetdb parameter when calling pytest\n\n\tpytest --resetdb.")
+            raise SystemError(
+                "Please note: The database seems to be populated.\n\tEither delete all nodes and edges manually, "
+                "or set the --resetdb parameter when calling pytest\n\n\tpytest --resetdb.")
         else:
-            clear_neo4j_database(db)        
+            clear_neo4j_database(db)
     except CypherError as ce:
         # Handle instance without password being changed
         if 'The credentials you provided were valid, but must be changed before you can use this instance' in str(ce):
             warnings.warn("New database with no password set, setting password to 'test'")
             change_neo4j_password(db, 'test')
-            db.set_connection('bolt://neo4j:test@localhost:7687')            
+            db.set_connection('bolt://neo4j:test@localhost:7687')
             warnings.warn("Please 'export NEO4J_BOLT_URL=bolt://neo4j:test@localhost:7687' for subsequent test runs")
         else:
             raise ce

--- a/test/test_transactions.py
+++ b/test/test_transactions.py
@@ -1,4 +1,7 @@
-from neo4j.addressing import AddressError
+try:
+    from neobolt.addressing import AddressError  # noqa  # using neobolt
+except ImportError:
+    from neo4j.addressing import AddressError  # noqa  #compat for neo-driver 1.6
 from pytest import raises
 
 from neomodel import db, StructuredNode, StringProperty, UniqueProperty
@@ -72,7 +75,6 @@ def test_query_inside_transaction():
 
 def test_set_connection_works():
     assert Person(name='New guy').save()
-    from socket import gaierror
 
     old_url = db.url
     with raises(AddressError):

--- a/tests-with-docker-compose.sh
+++ b/tests-with-docker-compose.sh
@@ -46,8 +46,8 @@ for dir in neomodel test; do
     find ${dir} -name __pycache__ -exec rm -Rf {} \;
 done
 
-for NEO4J_VERSION in 3.0 3.1 3.2 3.3; do
-    for PYTHON_VERSION in 2.7 3.4 3.5 3.6; do
+for NEO4J_VERSION in 3.3 3.4 3.5; do
+    for PYTHON_VERSION in 2.7 3.5 3.6; do
         write_compose_file
         docker-compose up -d neo4j
         docker-compose up tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,81 @@
+# this file is *not* meant to cover or endorse the use of tox or pytest or
+# testing in general,
+#
+#  It's meant to show the use of:
+#
+#  - check-manifest
+#     confirm items checked into vcs are in your sdist
+#  - python setup.py check (using the readme_renderer extension)
+#     confirms your long_description will render correctly on pypi
+#
+#  and also to help confirm pull requests to this project.
+
+[tox]
+envlist = py27, py34, py35, py36, py37, pypy, pypy3, dist_and_docs
+
+[travis]
+python =
+    3.6: py36, dist_and_docs
+
+[testenv]
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+deps =
+    pytest
+
+commands =
+    python setup.py test
+
+basepython =
+    py27: python2.7
+    py34: python3.4
+    py35: python3.5
+    py36: python3.6
+    py37: python3.7
+    pypy: pypy
+    pypy3: pypy3
+    py2: python2.7
+    py3: python3.6
+
+[testenv:py36]
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+deps =
+    pytest
+    coverage
+    coveralls
+
+commands =
+    coverage run --source=neomodel setup.py test
+    - coveralls
+
+[testenv:dist_and_docs]
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+basepython = python3.6
+deps =
+    check-manifest
+    flake8
+    pydocstyle
+    docutils
+commands =
+    flake8 pykechain
+    pydocstyle pykechain
+    python setup.py check -m -r -s
+
+
+# test settings
+[flake8]
+max-line-length = 120
+statistics = True
+
+[pydocstyle]
+ignore = D100,D105,D203,D212,D213
+
+#from: http://www.pydocstyle.org/en/latest/error_codes.html
+#D100	Missing docstring in public module
+#D105	Missing docstring in magic method
+#D203	1 blank line required before class docstring
+#D212	Multi-line docstring summary should start at the first line
+#D213	Multi-line docstring summary should start at the second line
+
+[pytest]
+addopts = -l --color=yes -v
+testpaths = test


### PR DESCRIPTION
* updated newer NEO4J_VERSIONS to include neo4j 3.4 and neo4j 3.5
* updated python 3.6/3.7 testing, added pypy and pypy3.5
* adding tox support
* neo4j.v1 is deprecated package, using neo4j instead for py3 version
* reimport AddressError from neobolt (instead of neo-driver) for py3 version