### PR TITLE
add possibility to filter traversal left hand statements

### DIFF
--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -240,7 +240,7 @@ class QueryBuilder(object):
                 self.build_order_by(ident, source)
 
             if source.filters or source.q_filters:
-                self.build_where_stmt(ident, source.filters, source.q_filters)
+                self.build_where_stmt(ident, source.filters, source.q_filters, source_class=source.source_class)
 
             return ident
         elif isinstance(source, StructuredNode):
@@ -335,18 +335,17 @@ class QueryBuilder(object):
             self._place_holder_registry[key] = 1
         return key + '_' + str(self._place_holder_registry[key])
 
-    def _parse_q_filters(self, ident, q):
-        cls = self.node_set.source_class
+    def _parse_q_filters(self, ident, q, source_class):
         target = []
         for child in q.children:
             if isinstance(child, QBase):
-                q_childs = self._parse_q_filters(ident, child)
+                q_childs = self._parse_q_filters(ident, child, source_class)
                 if child.connector == Q.OR:
                     q_childs = "(" + q_childs + ")"
                 target.append(q_childs)
             else:
                 kwargs = {child[0]: child[1]}
-                filters = process_filter_args(cls, kwargs)
+                filters = process_filter_args(source_class, kwargs)
                 for prop, op_and_val in filters.items():
                     op, val = op_and_val
                     if op in _UNARY_OPERATORS:
@@ -362,12 +361,12 @@ class QueryBuilder(object):
             ret = 'NOT ({})'.format(ret)
         return ret
 
-    def build_where_stmt(self, ident, filters, q_filters=None):
+    def build_where_stmt(self, ident, filters, q_filters=None, source_class=None):
         """
         construct a where statement from some filters
         """
         if q_filters is not None:
-            stmts = self._parse_q_filters(ident, q_filters)
+            stmts = self._parse_q_filters(ident, q_filters, source_class)
             if stmts:
                 self._ast['where'].append(stmts)
         else:

--- a/test/test_match_api.py
+++ b/test/test_match_api.py
@@ -344,3 +344,20 @@ def test_q_filters():
 
     coffees_5_not_japans = Coffee.nodes.filter(Q(price__gt=5) & ~Q(name="Japans finest")).all()
     assert c3 not in coffees_5_not_japans
+
+
+def test_traversal_filter_left_hand_statement():
+    nescafe = Coffee(name='Nescafe2', price=99).save()
+    nescafe_gold = Coffee(name='Nescafe gold', price=11).save()
+
+    tesco = Supplier(name='Sainsburys', delivery_cost=3).save()
+    biedronka = Supplier(name='Biedronka', delivery_cost=5).save()
+    lidl = Supplier(name='Lidl', delivery_cost=3).save()
+
+    nescafe.suppliers.connect(tesco)
+    nescafe_gold.suppliers.connect(biedronka)
+    nescafe_gold.suppliers.connect(lidl)
+
+    lidl_supplier = NodeSet(Coffee.nodes.filter(price=11).suppliers).filter(delivery_cost=3).all()
+
+    assert lidl in lidl_supplier


### PR DESCRIPTION
Filtering left hand traversal statement is not possible. Top level NodeSet source class is used to process filter args for all sources in the chain. 

For each NodeSet in the chain current source_class should be passed, not the top level.

This one was not possible
` NodeSet(Coffee.nodes.filter(price=11).suppliers).filter(delivery_cost=3).all() `
```
neomodel/match.py:469: in all
    return self.query_cls(self).build_ast()._execute()
neomodel/match.py:219: in build_ast
    self.build_source(self.node_set)
neomodel/match.py:235: in build_source
    ident = self.build_source(source.source)
neomodel/match.py:230: in build_source
    return self.build_traversal(source)
neomodel/match.py:271: in build_traversal
    lhs_ident = self.build_source(traversal.source)
neomodel/match.py:243: in build_source
    self.build_where_stmt(ident, source.filters, source.q_filters)
neomodel/match.py:370: in build_where_stmt
    stmts = self._parse_q_filters(ident, q_filters)
neomodel/match.py:343: in _parse_q_filters
    q_childs = self._parse_q_filters(ident, child)
neomodel/match.py:349: in _parse_q_filters
    filters = process_filter_args(cls, kwargs)

   if prop not in cls.defined_properties(rels=False):
>    raise ValueError("No such property {} on {}".format(prop, cls.__name__))
E    ValueError: No such property price on Supplier

neomodel/match.py:146: ValueError

```

after changes:
```
query:  MATCH ((coffee:Coffee)), ((coffee)<-[r1:`COFFEE SUPPLIERS`]-(suppliers:Supplier)) WHERE coffee.price = {coffee_price_1} AND suppliers.delivery_cost = {suppliers_delivery_cost_1} RETURN suppliers
params: {'suppliers_delivery_cost_1': 3, 'coffee_price_1': 11}
```
