### PR TITLE
Add _build_merge_query dynamic relationship direction

### DIFF
--- a/neomodel/core.py
+++ b/neomodel/core.py
@@ -267,14 +267,14 @@ class StructuredNode(NodeBase):
             if not relation_type:
                 raise ValueError('No relation_type is specified on provided relationship')
 
-            from .match import OUTGOING, _rel_helper
+            from .match import _rel_helper
 
             query_params["source_id"] = relationship.source.id
             query = "MATCH (source:{}) WHERE ID(source) = {{source_id}}\n ".format(relationship.source.__label__)
             query += "WITH source\n UNWIND {merge_params} as params \n "
             query += "MERGE "
-            query += _rel_helper(rhs='source', lhs=n_merge, ident=None,
-                                 relation_type=relation_type, direction=OUTGOING)
+            query += _rel_helper(lhs='source', rhs=n_merge, ident=None,
+                                 relation_type=relation_type, direction=relationship.definition['direction'])
 
         query += "ON CREATE SET n = params.create\n "
         # if update_existing, write properties on match as well


### PR DESCRIPTION
Hi,

I was using create_or_update to create node with a specified `relationship`, and I noticed `_rel_helper` function in `_build_merge_query` is always invoked with `OUTGOING` direction ignoring the `relationship` actual direction.
I thought it would be useful to use `relationship.definition['direction']`' instead (also, I had to adjust `lhs` and `rhs`), to dynamically determine the relationship direction.

Thanks.