### PR TITLE
Added safeguard for the accidental redefinition of a class mapping

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,13 @@ An Object Graph Mapper (OGM) for the neo4j_ graph database, built on the awesome
     :scale: 100%
     :target: https://neomodel.readthedocs.io/en/latest/?badge=latest
 
+
+! Support for Python 2.7 !
+==========================
+**Please note:** Version 3.3.1 will be the last version that `neomodel` provides suppport for Python 2.7. By its
+next major release, the project will focus solely on Python 3.*.
+
+
 Documentation
 =============
 
@@ -33,7 +40,7 @@ Available on readthedocs_.
 Requirements
 ============
 
-- Python 2.7, 3.4+
+- Python 2.7 (Up to version 3.3.1), 3.4+
 - neo4j 3.0, 3.1, 3.2, 3.3
 
 Installation
@@ -66,7 +73,7 @@ Ideas, bugs, tests and pull requests always welcome.
 Running the test suite
 ----------------------
 
-Make sure you have a Neo4j database version 3 or higher to run the tests on. (it will wipe this database for each test run)::
+Make sure you have a Neo4j database version 3 or higher to run the tests on.::
 
     $ export NEO4J_BOLT_URL=bolt://neo4j:neo4j@localhost:7687 # (the default)
 
@@ -77,7 +84,10 @@ Setup a virtual environment, install neomodel for development and run the test s
     $ python setup.py develop
     $ pytest
 
-If your running a neo4j database for the first time the test suite will set the password to 'test'.
+If you are running a neo4j database for the first time the test suite will set the password to 'test'.
+If the database is already populated, the test suite will abort with an error message and ask you to re-run it with the
+`--resetdb` switch. This is a safeguard to ensure that the test suite does not accidentally wipe out a database if
+you happen to not have restarted your Neo4j server to point to a (usually named) `debug.db` database.
 
 If you have ``docker-compose`` installed, you can run the test suite against all supported Python
 interpreters and neo4j versions::

--- a/doc/source/batch.rst
+++ b/doc/source/batch.rst
@@ -1,6 +1,6 @@
-======================
-Batch nodes operations
-======================
+=====================
+Batch node operations
+=====================
 
 All batch operations can be executed with one or more nodes.
 

--- a/doc/source/extending.rst
+++ b/doc/source/extending.rst
@@ -66,41 +66,141 @@ It is important to note that `StructuredNode`'s constructor will override proper
 Therefore constructor parameters must be passed via `kwargs` (as above). 
 These can also be set after calling the constructor but this would skip validation.
 
+.. _automatic_class_resolution:
 
-Caveats
--------
+Automatic class resolution
+--------------------------
+Neomodel is able to transform nodes to native data model objects, automatically, via a *node-class registry*
+that is progressively built up during the definition of the models.
 
-It is very important to realise that `neomodel` builds an internal mapping of the set of labels associated with a node
-to the Python class this node is supposed to be serialised to. This mapping is preserved **within the same process**.
+This *registry* is a dictionary that provides a mapping from the set of labels associated with a node to the class
+that is implied by this set of labels.
 
-This means that class names within a data model **must** be unique at least within the same process.
-
-The following simple example illustrates exactly the sort of problematic condition this might create::
+Consider for example the following snippet of code::
 
     import neomodel
 
-    # Once the following class gets defined, `neomodel` will create a mapping between the set of
-    # its labels and the class itself. Here, `Person` does not descend from any other class and therefore
-    # the mapping will be {"Person"}->class Person
-    class Person(neomodel.StructuredNode):
-        uid = neomodel.UniqueIdProperty()
-        full_name = neomodel.StringProperty()
 
-    def some_function():
-        # Class Person is local to `some_function`. This is perfectly valid Python
-        # but its definition would reset the existing `neomodel` mapping of
-        # {"Person"}->class Person, to {"Person"}->some_function.class Person
-        class Person(neomodel.StructuredNode):
-            uid = neomodel.UniqueIdProperty()
-            age = neomodel.IntegerProperty()
-
+    class BasePerson(neomodel.StructuredNode):
         pass
 
-    if __name__ == "__main__":
-        Person(full_name="Tex Murhpy").save()
-        some_function()
-        Person(full_name="Donald Byrd").save()
+
+    class TechnicalPerson(BasePerson):
+        pass
 
 
-This is disallowed in `neomodel` and an attempt to define a class whose labels are exactly the same as a class that has
-already been defined will lead to raising exception `ClassAlreadyDefined`.
+    class PilotPerson(BasePerson):
+        pass
+
+Once this script is executed, the *node-class registry* would contain the following entries: ::
+
+    {"BasePerson"}                    --> class BasePerson
+    {"BasePerson", "TechnicalPerson"} --> class TechnicalPerson
+    {"BasePerson", "PilotPerson"}     --> class PilotPerson
+
+Therefore, a ``Node`` with labels ``"BasePerson", "TechnicalPerson"`` would lead to the instantiation of a
+``TechnicalPerson`` object. This automatic resolution is **optional** and can be invoked automatically via
+``neomodel.Database.cypher_query`` if its ``resolve_objects`` parameter is set to ``True`` (the default is ``False``).
+
+This automatic class resolution however, requires a bit of caution:
+
+1. As a consequence of the way the *node-class registry* is built up and used, if a query results in instantiating an
+   object whose class definition has not yet been imported, then exception
+   ``neomodel.exceptions.ModelDefinitionMismatch`` will be raised.
+        * Given the above class hierarchy, suppose that each of the classes ``BasePerson``, ``TechnicalPerson``,
+          ``PilotPerson`` were defined in separate files / modules and a script only included::
+
+              from base_models import BasePerson
+              from pilot_models import PilotPerson
+
+          Then, this would mean that the ``BasePerson, TechnicalPerson --> TechnicalPerson`` entry would not have been
+          created in the node-class registry and therefore it would be impossible to resolve any `Node` objects (if
+          they happened to come up in a query) to an application specific object.
+
+2. Since the only way to resolve objects at runtime is this mapping of a set of labels to a class, then
+   this mapping **must** be guaranteed to be unique. Therefore, if for any reason a class gets **redefined**, then
+   exception ``neomodel.exceptions.ClassAlreadyDefined`` will be raised.
+        * Given the above class hierarchy, suppose that an attempt was made to redefine one of the existing classes in
+          the local scope of some function ::
+
+                import neomodel
+
+                class BasePerson(neomodel.StructuredNode):
+                    pass
+
+
+                class TechnicalPerson(BasePerson):
+                    pass
+
+
+                class PilotPerson(BasePerson):
+                    pass
+
+
+                def some_function():
+                    class PilotPerson(BasePerson):
+                        pass
+
+          If this was left unchecked and once ``some_function()`` executes, it would replace the mapping of
+          ``{"BasePerson", "PilotPerson"}`` to ``PilotPerson`` **in the global scope** with a mapping of the same
+          set of labels but towards the class defined within the **local scope** of ``some_function``.
+
+Both ``ModelDefinitionMismatch`` and ``ClassAlreadyDefined`` produce an error message that returns the labels of the
+node that created the problem (either the `Node` returned from the database or the class that was attempted to be
+redefined) as well as the state of the current *node-class registry*. These two pieces of information can be used to
+debug the model mismatch further.
+
+
+``neomodel`` under multiple processes and threads
+-------------------------------------------------
+It is very important to realise that neomodel preserves a mapping of the set of labels associated with the Neo4J
+Data Base Management System (DBMS) Node to the Python class this node corresponds to within a class hierarchy.
+Detailed information about this is available in :ref:`automatic_class_resolution`.
+
+This mapping is preserved **within the same process** along with **transaction information**.
+
+Once a script that uses neomodel starts up, it imports its model definitions and starts communicating with the
+database within its own process.
+
+* neomodel internally creates a new `session <https://neo4j.com/docs/driver-manual/1.7/sessions-transactions/>`_
+  and through that session creates any additional transactions if required.
+* neomodel internally creates and updates a node-class registry.
+* Any additional threads spun up from this process will re-use the node-class registry.
+* Multiple calls to transaction handling functions will re-use a transaction if one is already going on **within the
+  same thread**.
+    * Separate threads can start different transactions but all of these transactions will be executed within the
+      same session.
+
+A script can still use neomodel across more than one processes as long as it gets re-initialised within each process
+to the desired state. That is, once a new process starts, the ``neomodel.db`` object will be re-initialised and the new
+process would have to import any application specific models it requires for its operation. As the two processes are
+independent, they will start different *sessions* to the Neo4j DBMS.
+
+Any transactions occurring within the same session will take care of constraints and indices without any special care.
+However, transactions across different sessions are *not aware of each other* and therefore can lead to database
+exceptions.
+
+For example, if an entity is declared with a unique index on one of its properties and two threads spun up from the
+same process attempt a ``get_or_create``, then one of them will ``create`` the node and the other will ``get`` it.
+No exceptions will be raised and ``get_or_create`` would have proceeded as expected. However, if the exact same scenario
+was attempted over transactions in two completely different sessions, then ``get_or_create`` would appear to have
+proceeded as expected in both of them, but one of them would further receive an exception about violating the uniqueness
+constraint (which is not exactly what is expected when a ``get_or_create`` is executed).
+
+Both of these conditions: Multiple threads spun from a single process and multiple processes spun from a main process,
+are very relevant to the operation of neomodel over
+`Neo4J Clusters <https://neo4j.com/docs/operations-manual/current/clustering/>`_ and the way tests might be invoked.
+
+A high throughput cluster environment (a few CORE clusters surrounded by many READ_REPLICAs) can use neomodel with
+``bolt+routing:`` over *multiple threads* to issue parallel read queries (over explicitly declared READ transactions).
+The same however would not work for parallel WRITE transactions because they all get processed within the
+same session and there is no performance gain. In that case, the only solution would be to use neomodel over
+*multiple processes* but ensure beforehand that any operations will not create conflicts (or anticipate and resolve
+gracefully the exceptions that might be raised).
+
+Similar considerations should also be given when writing tests for specific test modes. For example, ``pytest``
+collects tests within a directory and launches them in their own context and ``pytest-xdist`` and ``pytest-forked``
+can run tests in a distributed / parallel mode. Exactly the same considerations regarding initialising / re-initialising
+neomodel apply here as well and at the very minimum, you should ensure that tests either re-use classes, wherever
+possible, or do not re-use the same class names within the same context of execution.
+

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -15,7 +15,7 @@ This needs to be called early on in your app, if you are using Django the `setti
 If you are using your neo4j server for the first time you will need to change the default password.
 This can be achieved by visiting the neo4j admin panel (default: http://localhost:7474 ).
 
-You can also change the connection url at any time by calling `set_connection`::
+You can also change the connection url at any time by calling ``set_connection``::
 
     from neomodel import db
     db.set_connection('bolt://neo4j:neo4j@localhost:7687')
@@ -48,13 +48,13 @@ Below is a definition of two types of node `Person` and `Country`::
         country = RelationshipTo(Country, 'IS_FROM')
 
 
-There is one type of relationship present `IS_FROM`, we are defining two different ways for traversing it
-one accessible via `Person` objects and one via `Country` objects
+There is one type of relationship present ``IS_FROM``, we are defining two different ways for traversing it
+one accessible via ``Person`` objects and one via ``Country`` objects
 
-We can use the `Relationship` class as opposed to the `RelationshipTo` or `RelationshipFrom`
+We can use the ``Relationship`` class as opposed to the ``RelationshipTo`` or ``RelationshipFrom``
 if we don't want to specify a direction.
 
-Neomodel automatically creates a label for each `StructuredNode` class in the database
+Neomodel automatically creates a label for each ``StructuredNode`` class in the database
 with the corresponding indexes and constraints.
 
 Setup constraints and indexes
@@ -90,12 +90,19 @@ Using convenience methods such as::
 Retrieving nodes
 ================
 
-Using the '.nodes' class property::
+Using the ``.nodes`` class property::
 
-    # raises Person.DoesNotExist if no match
+    # Return all nodes
+    all_nodes = Person.nodes.all()
+
+    # Returns Person by Person.name=='Jim' or raises Person.DoesNotExist if no match
     jim = Person.nodes.get(name='Jim')
 
-    # Will return None unless bob exists
+
+``.nodes.all()`` and ``.nodes.get()`` can also accept a ``lazy=True`` parameter which will result in those functions
+simply returning the node IDs rather than every attribute associated with that Node. ::
+
+    # Will return None unless "bob" exists
     someone = Person.nodes.get_or_none(name='bob')
 
     # Will return the first Person node with the name bob. This raises Person.DoesNotExist if there's no match.
@@ -139,3 +146,4 @@ Working with relationships::
     jim.country.connect(usa)
     # Replace Jim's country relationship with a new one
     jim.country.replace(germany)
+

--- a/doc/source/queries.rst
+++ b/doc/source/queries.rst
@@ -22,9 +22,9 @@ Neomodel contains an API for querying sets of nodes without having to write cyph
 Node sets and filtering
 =======================
 
-The `nodes` property of a class returns all nodes of that type from the database.
+The ``.nodes`` property of a class returns all nodes of that type from the database.
 
-This set (or `NodeSet`) can be iterated over and filtered on. Under the hood it uses labels introduced in neo4j 2::
+This set (or `NodeSet`) can be iterated over and filtered on. Under the hood it uses labels introduced in Neo4J 2::
 
     # nodes with label Coffee whose price is greater than 2
     Coffee.nodes.filter(price__gt=2)
@@ -185,3 +185,4 @@ Removing the ordering from a previously defined query, is done by passing `None`
 For random ordering simply pass '?' to the order_by method::
 
     Coffee.nodes.order_by('?')
+

--- a/doc/source/relationships.rst
+++ b/doc/source/relationships.rst
@@ -3,7 +3,7 @@ Relationships
 =============
 
 Establishing an undirected relationship between two entities is done via the `Relationship` 
-class. This requires the class of the connected entity as well as the type of the relationship.
+class. This requires the class of the connected entity as well as the type of the relationship.::
 
     class Person(StructuredNode):
         friends = Relationship('Person', 'FRIEND')
@@ -152,36 +152,6 @@ Here is a minimal example to demonstrate that::
         
 This will show two friends connected with node "Grumpy", one of which is a ``TechnicalPerson`` 
 and the other a ``PilotPerson``.
-
-
-Automatic class resolution
---------------------------
-
-Neomodel is able to transform nodes to objects, automatically, via a *node-class registry* 
-that is progressively built up during the definition of the models.
-
-The dictionary provides a mapping from the set of labels associated with a node to the class 
-that is implied by this set of labels. In the example above, the *node-class registry* would contain 
-the following entries:
-
-    * BasePerson                  --> BasePerson
-    * BasePerson, TechnicalPerson --> TechnicalPerson
-    * BasePerson, PilotPerson     --> PilotPerson
-    
-This automatic resolution is effected by ``neomodel.Database.cypher_objectaware_query`` which is 
-invoked automatically where needed but it can also be invoked in exactly the same way as ``neomodel.
-Database.cypher_query``, manually, wherever this functionality may be needed.
-
-Doing so however, requires a bit of caution. As a consequence of the way the *node-class registry* is 
-built up and used, if ``BasePerson``, ``TechnicalPerson``, ``PilotPerson`` were defined 
-in separate files / modules and one of them was not loaded prior to a query to the database, then the 
-*node-class registry* would be unaware of the labels that leads to that particular class and would raise 
-``neomodel.exception.ModelDefinitionMismatch``.
-
-If the exception is not handled, it produces an error message that returns the labels of the node that 
-was retrieved from the database as well as the current *node-class registry*. These two pieces of 
-information can be used to debug the model mismatch further.
-    
 
 Explicit Traversal
 ==================

--- a/doc/source/spatial_properties.rst
+++ b/doc/source/spatial_properties.rst
@@ -94,7 +94,7 @@ marshalling for it.
 2. Default values (via `default=neomodel.contrib.spatial_properties.NeomodelPoint(...)` or a callable that must return
    a `NeomodelPoint`.
 3. Participation of `NeomodelPoint` in elements of `ArrayProperty` (via the `base_property` keyword of
-:class:`~neomodel.properties.ArrayProperty`)
+   :class:`~neomodel.properties.ArrayProperty`)
 
 But more importantly, during their definition, `PointProperty` properties **require their `crs` to be set**. If a
 `PointProperty` instantiation does not involve its `crs` an exception will be raised.

--- a/neomodel/core.py
+++ b/neomodel/core.py
@@ -3,7 +3,7 @@ import sys
 import warnings
 
 from neomodel import config
-from neomodel.exceptions import DoesNotExist
+from neomodel.exceptions import DoesNotExist, ClassAlreadyDefined
 from neomodel.hooks import hooks
 from neomodel.properties import Property, PropertyManager
 from neomodel.util import Database, classproperty, _UnsavedNode, _get_node_properties
@@ -171,8 +171,13 @@ class NodeMeta(type):
 
             if config.AUTO_INSTALL_LABELS:
                 install_labels(cls)
-            db._NODE_CLASS_REGISTRY[frozenset(cls.inherited_labels())] = cls
-            
+
+            label_set = frozenset(cls.inherited_labels())
+            if label_set not in db._NODE_CLASS_REGISTRY:
+                db._NODE_CLASS_REGISTRY[label_set] = cls
+            else:
+                raise ClassAlreadyDefined(cls, db._NODE_CLASS_REGISTRY)
+
         return cls
 
 

--- a/neomodel/util.py
+++ b/neomodel/util.py
@@ -56,6 +56,12 @@ class NodeClassRegistry:
     def __init__(self):
         self.__dict__['_NODE_CLASS_REGISTRY'] = self._NODE_CLASS_REGISTRY
 
+    def __str__(self):
+        ncr_items = list(map(lambda x: "{} --> {}".format(",".join(x[0]), x[1]),
+                         self._NODE_CLASS_REGISTRY.items()))
+        return "\n".join(ncr_items)
+
+
 
 class Database(local, NodeClassRegistry):
     """

--- a/test/test_contrib/test_spatial_datatypes.py
+++ b/test/test_contrib/test_spatial_datatypes.py
@@ -167,26 +167,26 @@ def test_prohibited_constructor_forms():
     check_and_skip_neo4j_least_version(340, 'This version does not support spatial data types.')
 
     # Absurd CRS
-    with pytest.raises(ValueError, message='Expected ValueError("Invalid CRS...")'):
+    with pytest.raises(ValueError, match='Invalid CRS\(blue_hotel\)'):
         new_point = neomodel.contrib.spatial_properties.NeomodelPoint((0,0), crs='blue_hotel')
 
     # Absurd coord dimensionality
-    with pytest.raises(ValueError, message='Expected ValueError("Invalid vector dimensions...")'):
+    with pytest.raises(ValueError, match='Invalid vector dimensions. Expected 2 or 3, received 7'):
         new_point = neomodel.contrib.spatial_properties.NeomodelPoint((0,0,0,0,0,0,0), crs='cartesian')
 
     # Absurd datatype passed to copy constructor
-    with pytest.raises(TypeError, message='Expected TypeError("Invalid object passed to copy constructor...")'):
+    with pytest.raises(TypeError, match='Invalid object passed to copy constructor'):
         new_point = neomodel.contrib.spatial_properties.NeomodelPoint('it don''t mean a thing if it '
                                                                       'ain''t got that swing', crs='cartesian')
 
     # Trying to instantiate a point with any of BOTH x,y,z or longitude, latitude, height
-    with pytest.raises(ValueError, message='Expected ValueError("Invalid instantiation via arguments...")'):
+    with pytest.raises(ValueError, match='Invalid instantiation via arguments'):
         new_point = neomodel.contrib.spatial_properties.NeomodelPoint(x=0.0, y=0.0,
                                                                       longitude=0.0, latitude=2.0, height=-2.0,
                                                                       crs='cartesian')
 
     # Trying to instantiate a point with absolutely NO parameters
-    with pytest.raises(ValueError, message='Expected ValueError("Invalid instantiation via no arguments...")'):
+    with pytest.raises(ValueError, match='Invalid instantiation via no arguments'):
         new_point = neomodel.contrib.spatial_properties.NeomodelPoint()
 
 
@@ -202,20 +202,20 @@ def test_property_accessors_depending_on_crs():
 
     # Geometrical points only have x,y,z coordinates
     new_point = neomodel.contrib.spatial_properties.NeomodelPoint((0.0, 0.0, 0.0), crs='cartesian-3d')
-    with pytest.raises(AttributeError, message='Expected AttributeError("Invalid coordinate(''longitude'')...")'):
+    with pytest.raises(AttributeError, match='Invalid coordinate \("longitude"\)'):
         new_point.longitude
-    with pytest.raises(AttributeError, message='Expected AttributeError("Invalid coordinate(''latitude'')...")'):
+    with pytest.raises(AttributeError, match='Invalid coordinate \("latitude"\)'):
         new_point.latitude
-    with pytest.raises(AttributeError, message='Expected AttributeError("Invalid coordinate(''height'')...")'):
+    with pytest.raises(AttributeError, match='Invalid coordinate \("height"\)'):
         new_point.height
 
     # Geographical points only have longitude, latitude, height coordinates
     new_point = neomodel.contrib.spatial_properties.NeomodelPoint((0.0, 0.0, 0.0), crs='wgs-84-3d')
-    with pytest.raises(AttributeError, message='Expected AttributeError("Invalid coordinate(''x'')...")'):
+    with pytest.raises(AttributeError, match='Invalid coordinate \("x"\)'):
         new_point.x
-    with pytest.raises(AttributeError, message='Expected AttributeError("Invalid coordinate(''y'')...")'):
+    with pytest.raises(AttributeError, match='Invalid coordinate \("y"\)'):
         new_point.y
-    with pytest.raises(AttributeError, message='Expected AttributeError("Invalid coordinate(''z'')...")'):
+    with pytest.raises(AttributeError, match='Invalid coordinate \("z"\)'):
         new_point.z
 
 

--- a/test/test_contrib/test_spatial_properties.py
+++ b/test/test_contrib/test_spatial_properties.py
@@ -23,13 +23,13 @@ def test_spatial_point_property():
     # Neo4j versions lower than 3.4.0 do not support Point. In that case, skip the test.
     check_and_skip_neo4j_least_version(340, 'This version does not support spatial data types.')
 
-    with pytest.raises(ValueError, message='Expected ValueError("Invalid CRS (CRS not specified)")'):
+    with pytest.raises(ValueError, match='Invalid CRS\(None\)'):
         a_point_property = neomodel.contrib.spatial_properties.PointProperty()
 
-    with pytest.raises(ValueError, message='Expected ValueError("Invalid CRS (CRS not acceptable)")'):
+    with pytest.raises(ValueError, match='Invalid CRS\(crs_isaak\)'):
         a_point_property = neomodel.contrib.spatial_properties.PointProperty(crs='crs_isaak')
 
-    with pytest.raises(TypeError, message='Expected TypeError("Invalid default value")'):
+    with pytest.raises(TypeError, match='Invalid default value'):
         a_point_property = neomodel.contrib.spatial_properties.PointProperty(default=(0.0, 0.0), crs='cartesian')
 
 

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -3,14 +3,14 @@ import pickle
 from neomodel import StructuredNode, StringProperty, DoesNotExist
 
 
-class Person(StructuredNode):
+class EPerson(StructuredNode):
     name = StringProperty(unique_index=True)
 
 
 def test_object_does_not_exist():
     try:
-        Person.nodes.get(name="johnny")
-    except Person.DoesNotExist as e:
+        EPerson.nodes.get(name="johnny")
+    except EPerson.DoesNotExist as e:
         pickle_instance = pickle.dumps(e)
         assert pickle_instance
         assert pickle.loads(pickle_instance)
@@ -21,8 +21,8 @@ def test_object_does_not_exist():
 
 def test_pickle_does_not_exist():
     try:
-        raise Person.DoesNotExist("My Test Message")
-    except Person.DoesNotExist as e:
+        raise EPerson.DoesNotExist("My Test Message")
+    except EPerson.DoesNotExist as e:
         pickle_instance = pickle.dumps(e)
         assert pickle_instance
         assert pickle.loads(pickle_instance)

--- a/test/test_issue283.py
+++ b/test/test_issue283.py
@@ -272,3 +272,18 @@ def test_node_label_mismatch():
     with pytest.raises(neomodel.exceptions.ModelDefinitionMismatch):            
         for some_friend in A.friends_with:
             print(some_friend.name)
+
+
+def test_attempted_class_redefinition():
+    """
+    A neomodel.StructuredNode class is attempted to be redefined.
+    """
+    def redefine_class_locally():
+        # Since this test has already set up a class hierarchy in its global scope, we will try to redefine
+        # SomePerson here.
+        # The internal structure of the SomePerson entity does not matter at all here.
+        class SomePerson(BaseOtherPerson):
+            uid = neomodel.UniqueIdProperty()
+
+    with pytest.raises(neomodel.exceptions.ClassAlreadyDefined):
+        redefine_class_locally()

--- a/test/test_properties.py
+++ b/test/test_properties.py
@@ -158,7 +158,7 @@ def test_default_value_callable():
     assert a.uid == 'xx'
 
 
-def test_default_valude_callable_type():
+def test_default_value_callable_type():
     # check our object gets converted to str without serializing and reload
     def factory():
         class Foo(object):
@@ -178,14 +178,14 @@ def test_default_valude_callable_type():
 
 
 def test_independent_property_name():
-    class TestNode(StructuredNode):
+    class TestDBNamePropertyNode(StructuredNode):
         name_ = StringProperty(db_property="name")
-    x = TestNode()
+    x = TestDBNamePropertyNode()
     x.name_ = "jim"
     x.save()
 
     # check database property name on low level
-    results, meta = db.cypher_query("MATCH (n:TestNode) RETURN n")
+    results, meta = db.cypher_query("MATCH (n:TestDBNamePropertyNode) RETURN n")
     node_properties = _get_node_properties(results[0][0])
     assert node_properties['name'] == "jim"
 
@@ -193,8 +193,8 @@ def test_independent_property_name():
     assert not 'name_' in node_properties
     assert not hasattr(x, 'name')
     assert hasattr(x, 'name_')
-    assert TestNode.nodes.filter(name_="jim").all()[0].name_ == x.name_
-    assert TestNode.nodes.get(name_="jim").name_ == x.name_
+    assert TestDBNamePropertyNode.nodes.filter(name_="jim").all()[0].name_ == x.name_
+    assert TestDBNamePropertyNode.nodes.get(name_="jim").name_ == x.name_
 
     x.delete()
 

--- a/test/test_relationships.py
+++ b/test/test_relationships.py
@@ -4,11 +4,11 @@ from neomodel import (StructuredNode, RelationshipTo, RelationshipFrom, Relation
                       StringProperty, IntegerProperty, StructuredRel, One)
 
 
-class Person(StructuredNode):
+class PersonWithRels(StructuredNode):
     name = StringProperty(unique_index=True)
     age = IntegerProperty(index=True)
     is_from = RelationshipTo('Country', 'IS_FROM')
-    knows = Relationship(u'Person', 'KNOWS')  # use unicode to check issue
+    knows = Relationship(u'PersonWithRels', 'KNOWS')  # use unicode to check issue
 
     @property
     def special_name(self):
@@ -20,11 +20,11 @@ class Person(StructuredNode):
 
 class Country(StructuredNode):
     code = StringProperty(unique_index=True)
-    inhabitant = RelationshipFrom(Person, 'IS_FROM')
-    president = RelationshipTo(Person, 'PRESIDENT', cardinality=One)
+    inhabitant = RelationshipFrom(PersonWithRels, 'IS_FROM')
+    president = RelationshipTo(PersonWithRels, 'PRESIDENT', cardinality=One)
 
 
-class SuperHero(Person):
+class SuperHero(PersonWithRels):
     power = StringProperty(index=True)
 
     def special_power(self):
@@ -32,7 +32,7 @@ class SuperHero(Person):
 
 
 def test_actions_on_deleted_node():
-    u = Person(name='Jim2', age=3).save()
+    u = PersonWithRels(name='Jim2', age=3).save()
     u.delete()
     with raises(ValueError):
         u.is_from.connect(None)
@@ -45,7 +45,7 @@ def test_actions_on_deleted_node():
 
 
 def test_bidirectional_relationships():
-    u = Person(name='Jim', age=3).save()
+    u = PersonWithRels(name='Jim', age=3).save()
     assert u
 
     de = Country(code='DE').save()
@@ -74,8 +74,8 @@ def test_bidirectional_relationships():
 
 
 def test_either_direction_connect():
-    rey = Person(name='Rey', age=3).save()
-    sakis = Person(name='Sakis', age=3).save()
+    rey = PersonWithRels(name='Rey', age=3).save()
+    sakis = PersonWithRels(name='Sakis', age=3).save()
 
     rey.knows.connect(sakis)
     assert rey.knows.is_connected(sakis)
@@ -96,7 +96,7 @@ def test_either_direction_connect():
 
 
 def test_search_and_filter_and_exclude():
-    fred = Person(name='Fred', age=13).save()
+    fred = PersonWithRels(name='Fred', age=13).save()
     zz = Country(code='ZZ').save()
     zx = Country(code='ZX').save()
     zt = Country(code='ZY').save()
@@ -114,7 +114,7 @@ def test_search_and_filter_and_exclude():
 
 
 def test_custom_methods():
-    u = Person(name='Joe90', age=13).save()
+    u = PersonWithRels(name='Joe90', age=13).save()
     assert u.special_power() == "I have no powers"
     u = SuperHero(name='Joe91', age=13, power='xxx').save()
     assert u.special_power() == "I have powers"
@@ -122,10 +122,10 @@ def test_custom_methods():
 
 
 def test_valid_reconnection():
-    p = Person(name='ElPresidente', age=93).save()
+    p = PersonWithRels(name='ElPresidente', age=93).save()
     assert p
 
-    pp = Person(name='TheAdversary', age=33).save()
+    pp = PersonWithRels(name='TheAdversary', age=33).save()
     assert pp
 
     c = Country(code='CU').save()
@@ -144,16 +144,16 @@ def test_valid_reconnection():
 
 
 def test_valid_replace():
-    brady = Person(name='Tom Brady', age=40).save()
+    brady = PersonWithRels(name='Tom Brady', age=40).save()
     assert brady
 
-    gronk = Person(name='Rob Gronkowski', age=28).save()
+    gronk = PersonWithRels(name='Rob Gronkowski', age=28).save()
     assert gronk
 
-    colbert = Person(name='Stephen Colbert', age=53).save()
+    colbert = PersonWithRels(name='Stephen Colbert', age=53).save()
     assert colbert
 
-    hanks = Person(name='Tom Hanks', age=61).save()
+    hanks = PersonWithRels(name='Tom Hanks', age=61).save()
     assert hanks
 
     brady.knows.connect(gronk)
@@ -170,7 +170,7 @@ def test_valid_replace():
 
 
 def test_props_relationship():
-    u = Person(name='Mar', age=20).save()
+    u = PersonWithRels(name='Mar', age=20).save()
     assert u
 
     c = Country(code='AT').save()

--- a/test/test_transactions.py
+++ b/test/test_transactions.py
@@ -4,37 +4,37 @@ from pytest import raises
 from neomodel import db, StructuredNode, StringProperty, UniqueProperty
 
 
-class Person(StructuredNode):
+class APerson(StructuredNode):
     name = StringProperty(unique_index=True)
 
 
 def test_rollback_and_commit_transaction():
-    for p in Person.nodes:
+    for p in APerson.nodes:
         p.delete()
 
-    Person(name='Roger').save()
+    APerson(name='Roger').save()
 
     db.begin()
-    Person(name='Terry S').save()
+    APerson(name='Terry S').save()
     db.rollback()
 
-    assert len(Person.nodes) == 1
+    assert len(APerson.nodes) == 1
 
     db.begin()
-    Person(name='Terry S').save()
+    APerson(name='Terry S').save()
     db.commit()
 
-    assert len(Person.nodes) == 2
+    assert len(APerson.nodes) == 2
 
 
 @db.transaction
 def in_a_tx(*names):
     for n in names:
-        Person(name=n).save()
+        APerson(name=n).save()
 
 
 def test_transaction_decorator():
-    for p in Person.nodes:
+    for p in APerson.nodes:
         p.delete()
 
     # should work
@@ -45,33 +45,33 @@ def test_transaction_decorator():
     with raises(UniqueProperty):
         in_a_tx('Jim', 'Roger')
 
-    assert 'Jim' not in [p.name for p in Person.nodes]
+    assert 'Jim' not in [p.name for p in APerson.nodes]
 
 
 def test_transaction_as_a_context():
     with db.transaction:
-        Person(name='Tim').save()
+        APerson(name='Tim').save()
 
-    assert Person.nodes.filter(name='Tim')
+    assert APerson.nodes.filter(name='Tim')
 
     with raises(UniqueProperty):
         with db.transaction:
-            Person(name='Tim').save()
+            APerson(name='Tim').save()
 
 
 def test_query_inside_transaction():
-    for p in Person.nodes:
+    for p in APerson.nodes:
         p.delete()
 
     with db.transaction:
-        Person(name='Alice').save()
-        Person(name='Bob').save()
+        APerson(name='Alice').save()
+        APerson(name='Bob').save()
 
-        assert len([p.name for p in Person.nodes]) == 2
+        assert len([p.name for p in APerson.nodes]) == 2
 
 
 def test_set_connection_works():
-    assert Person(name='New guy').save()
+    assert APerson(name='New guy').save()
     from socket import gaierror
 
     old_url = db.url
@@ -79,4 +79,4 @@ def test_set_connection_works():
         db.set_connection('bolt://user:password@nowhere:7687')
     db.set_connection(old_url)
     # set connection back
-    assert Person(name='New guy2').save()
+    assert APerson(name='New guy2').save()


### PR DESCRIPTION
Please see `doc/extending.rst` section "Caveats" for a detailed explanation of the safeguard added with this commit.

An exception (`ClassAlreadyDefined`) is raised, if a class is attempted to be defined that happens to have exactly the same set of labels with another class that may have already been defined within the node-to-class registry.