### PR TITLE
Fix log format for logging cypher queries and response time

### DIFF
--- a/neomodel/util.py
+++ b/neomodel/util.py
@@ -238,7 +238,7 @@ class Database(local, NodeClassRegistry):
             raise
 
         if os.environ.get('NEOMODEL_CYPHER_DEBUG', False):
-            logger.debug("query: " + query + "\nparams: " + repr(params) + "\ntook: {:.2g}s\n".format(end - start))
+            logger.debug("query: {}\ntook: {:f}s\n".format(query, end - start), extra=params)
 
         return results, meta
         

--- a/neomodel/util.py
+++ b/neomodel/util.py
@@ -238,7 +238,7 @@ class Database(local, NodeClassRegistry):
             raise
 
         if os.environ.get('NEOMODEL_CYPHER_DEBUG', False):
-            logger.debug("query: {}\ntook: {:f}s\n".format(query, end - start), extra=params)
+            logger.debug("query: " + query + "\nparams: " + repr(params) + "\ntook: {:f}s\n".format(end - start))
 
         return results, meta
         


### PR DESCRIPTION
use `{:f}` instead of `{:.2g}` 