### PR TITLE
Fix string representation of exception ModelDefinitionMismatch

### DIFF
--- a/neomodel/exceptions.py
+++ b/neomodel/exceptions.py
@@ -59,7 +59,7 @@ class ModelDefinitionMismatch(ModelDefinitionException):
     In either of these cases the mismatch must be reported
     """
     def __str__(self):
-        node_labels = ",".join(self.db_node_class.labels())
+        node_labels = ",".join(self.db_node_class.labels)
 
         return "Node with labels {} does not resolve to any of the known " \
                "objects\n{}\n".format(node_labels, str(self.current_node_class_registry))


### PR DESCRIPTION
For neo4j-driver 1.6.x Node.labels is a `@property` and not a method

https://github.com/neo4j/neo4j-python-driver/blob/1.6/neo4j/v1/types/graph.py#L206