### PR TITLE
Fix the neo4j-driver config kwargs passed to GraphDatabase.driver

### DIFF
--- a/neomodel/util.py
+++ b/neomodel/util.py
@@ -92,7 +92,7 @@ class Database(local, NodeClassRegistry):
         self.driver = GraphDatabase.driver(u.scheme + '://' + hostname,
                                            auth=basic_auth(username, password),
                                            encrypted=config.ENCRYPTED_CONNECTION,
-                                           max_pool_size=config.MAX_POOL_SIZE)
+                                           max_connection_pool_size=config.MAX_POOL_SIZE)
         self.url = url
         self._pid = os.getpid()
         self._active_transaction = None


### PR DESCRIPTION
The correct name of the config is `max_connection_pool_size`
https://neo4j.com/docs/api/python-driver/1.6/driver.html?highlight=max_connection_pool_size#max-connection-pool-size