### PR TITLE
Optional labels

### DIFF
--- a/doc/source/extending.rst
+++ b/doc/source/extending.rst
@@ -21,6 +21,26 @@ Creating purely abstract classes is achieved using the `__abstract_node__` prope
             self.balance = self.balance + int(amount)
             self.save()
 
+
+Optional Labels
+---------------
+Sometimes it is useful to allow a node to have extra labels in addition to the
+ones Neomodel defines by default using class names.
+
+Nemodel constructs sets of labels to give to a node in Neo4j by looking at the
+names of the node classes that node is/inherits from. It also constructs a
+mapping of the reverse, expected node labels to node classes, in order to do
+object resolution.
+
+In order for object resolution to work on Node Classes that could have extra
+labels, the `__optional_labels__` property must be defined as a list of strings::
+
+    class Shopper(StructuredNode):
+        __optional_labels__ = ["SuperSaver", "SeniorDiscount"]
+        balance = IntegerProperty(index=True)
+
+.. warning:: The size of the node class mapping grows exponentially with optional labels. Use with some caution.
+
 Mixins
 ------
 Mixins can be used to share functionality between nodes classes::

--- a/neomodel/core.py
+++ b/neomodel/core.py
@@ -183,8 +183,9 @@ class NodeMeta(type):
                 for i in range(1, len(optional_label_set) + 1)
                 for x in combinations(optional_label_set, i)
             ]
+            possible_label_combinations.append(base_label_set)
 
-            for label_set in [base_label_set, *possible_label_combinations]:
+            for label_set in possible_label_combinations:
                 if label_set not in db._NODE_CLASS_REGISTRY:
                     db._NODE_CLASS_REGISTRY[label_set] = cls
                 else:

--- a/neomodel/core.py
+++ b/neomodel/core.py
@@ -175,7 +175,7 @@ class NodeMeta(type):
                 install_labels(cls)
 
             base_label_set = frozenset(cls.inherited_labels())
-            optional_label_set = set(cls.optional_labels())
+            optional_label_set = set(cls.inherited_optional_labels())
 
             # Construct all possible combinations of labels + optional labels
             possible_label_combinations = [
@@ -487,7 +487,7 @@ class StructuredNode(NodeBase):
                 scls, '__abstract_node__')]
 
     @classmethod
-    def optional_labels(cls):
+    def inherited_optional_labels(cls):
         """
         Return list of optional labels from nodes class hierarchy.
 

--- a/neomodel/core.py
+++ b/neomodel/core.py
@@ -169,7 +169,7 @@ class NodeMeta(type):
             )
 
             cls.__label__ = namespace.get('__label__', name)
-            cls.__optional_labels__ = namespace.get('__optional_labels__', name)
+            cls.__optional_labels__ = namespace.get('__optional_labels__', [])
 
             if config.AUTO_INSTALL_LABELS:
                 install_labels(cls)

--- a/neomodel/core.py
+++ b/neomodel/core.py
@@ -174,7 +174,7 @@ class NodeMeta(type):
             if config.AUTO_INSTALL_LABELS:
                 install_labels(cls)
 
-            base_label_set = set(cls.inherited_labels())
+            base_label_set = frozenset(cls.inherited_labels())
             optional_label_set = set(cls.optional_labels())
 
             # Construct all possible combinations of labels + optional labels
@@ -184,7 +184,7 @@ class NodeMeta(type):
                 for x in combinations(optional_label_set, i)
             ]
 
-            for label_set in possible_label_combinations:
+            for label_set in [base_label_set, *possible_label_combinations]:
                 if label_set not in db._NODE_CLASS_REGISTRY:
                     db._NODE_CLASS_REGISTRY[label_set] = cls
                 else:

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -223,12 +223,11 @@ def test_inheritance():
 
 
 def test_optional_labels():
-    print("TEST OPTIONAL LABELS")
-    class User(StructuredNode):
+    class BaseOptional(StructuredNode):
         __optional_labels__ = ["Alive"]
         name = StringProperty(unique_index=True)
 
-    class Shopper(User):
+    class ExtendedOptional(BaseOptional):
         __optional_labels__ = ["RewardsMember"]
         balance = IntegerProperty(index=True)
 
@@ -236,15 +235,15 @@ def test_optional_labels():
             self.balance = self.balance + int(amount)
             self.save()
 
-    jim = Shopper(name='jimmy', balance=300).save()
-    jim.credit_account(50)
+    henry = ExtendedOptional(name='henry', balance=300).save()
+    henry.credit_account(50)
 
-    assert Shopper.__label__ == 'Shopper'
-    assert jim.balance == 350
-    assert len(jim.inherited_labels()) == 2
-    assert len(jim.labels()) == 2
+    assert ExtendedOptional.__label__ == 'ExtendedOptional'
+    assert henry.balance == 350
+    assert len(henry.inherited_labels()) == 2
+    assert len(henry.labels()) == 2
     
-    assert jim.optional_labels() == ["Alive", "RewardsMember"]
+    assert set(henry.optional_labels()) == {"Alive", "RewardsMember"}
 
 
 def test_mixins():

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -222,7 +222,7 @@ def test_inheritance():
     assert jim.labels()[0] == 'Shopper'
 
 
-def test_optional_labels():
+def test_inherited_optional_labels():
     class BaseOptional(StructuredNode):
         __optional_labels__ = ["Alive"]
         name = StringProperty(unique_index=True)
@@ -243,7 +243,7 @@ def test_optional_labels():
     assert len(henry.inherited_labels()) == 2
     assert len(henry.labels()) == 2
     
-    assert set(henry.optional_labels()) == {"Alive", "RewardsMember"}
+    assert set(henry.inherited_optional_labels()) == {"Alive", "RewardsMember"}
 
 
 def test_mixins():

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -222,6 +222,31 @@ def test_inheritance():
     assert jim.labels()[0] == 'Shopper'
 
 
+def test_optional_labels():
+    print("TEST OPTIONAL LABELS")
+    class User(StructuredNode):
+        __optional_labels__ = ["Alive"]
+        name = StringProperty(unique_index=True)
+
+    class Shopper(User):
+        __optional_labels__ = ["RewardsMember"]
+        balance = IntegerProperty(index=True)
+
+        def credit_account(self, amount):
+            self.balance = self.balance + int(amount)
+            self.save()
+
+    jim = Shopper(name='jimmy', balance=300).save()
+    jim.credit_account(50)
+
+    assert Shopper.__label__ == 'Shopper'
+    assert jim.balance == 350
+    assert len(jim.inherited_labels()) == 2
+    assert len(jim.labels()) == 2
+    
+    assert jim.optional_labels() == ["Alive", "RewardsMember"]
+
+
 def test_mixins():
     class UserMixin(object):
         name = StringProperty(unique_index=True)


### PR DESCRIPTION
Adds optional labels, then registers classes to the map with these in mind.

One test is included.

You just add some `__optional_labels__` to a class like so:
```python
class Person(StructuredNode):
    __optional_labels__ = ["Alive", "Contributor"]
    name = StringProperty()
```

This solution has to examine the optional labels only once per class on startup and doesn't affect query time performance. It just packs the class dict a little tighter but lookup is O(1) there.



I took a swing at doing the label diff calculations at query time, but I really feel like this is a better solution. To determine all this at query time, you would have to do something like the following:

```diff
diff --git a/neomodel/util.py b/neomodel/util.py
index b1946a8..664f6b6 100644
--- a/neomodel/util.py
+++ b/neomodel/util.py
@@ -162,8 +162,18 @@ class Database(local, NodeClassRegistry):
                     resolved_object = a_result_attribute[1]

                     if type(a_result_attribute[1]) is Node:
-                        resolved_object = self._NODE_CLASS_REGISTRY[frozenset(a_result_attribute[1].labels)].inflate(
-                            a_result_attribute[1])
+                        existing_labels = set(a_result_attribute[1].labels)
+
+                        important_labels = frozenset(existing_labels.difference(global_optional_labels))
+                        optional_labels = existing_labels.intersection(global_optional_label_list)
+
+                        matching_class = self._NODE_CLASS_REGISTRY[important_labels]
+
+                        if not optional_labels.issubset(set(matching_class.__optional_labels__)):
+                            # There must be unaccounted for labels present
+                            raise ModelDefinitionMismatch(a_result_attribute[1], self._NODE_CLASS_REGISTRY)
+
+                        resolved_object = matching_class.inflate(a_result_attribute[1])

                     if type(a_result_attribute[1]) is list:
                         resolved_object = self._object_resolution([a_result_attribute[1]])
```
Note that this approach would require either maintaining a list `global_optional_labels`, effectively detaching them from the models, which I didn't like. You could gather the list from all the models, but that is inflexible (and requires recompilation all the time).

Anyway, let me know what you think!