### PR TITLE
fix in setup.py find_packages to exclude test package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     zip_safe=True,
     url='http://github.com/neo4j-contrib/neomodel',
     license='MIT',
-    packages=find_packages(exclude=('tests',)),
+    packages=find_packages(exclude=('test', 'test.*')),
     keywords='graph neo4j ORM OGM',
     scripts=['scripts/neomodel_install_labels', 'scripts/neomodel_remove_labels'],
     setup_requires=['pytest-runner'] if any(x in ('pytest', 'test') for x in sys.argv) else [],


### PR DESCRIPTION
Fixes `setup.py` implementation to properly exclude `test` package and `test.test_contrib` subpackage

Checked it is working as follows:
```
>>> from setuptools import setup, find_packages
>>> find_packages(exclude=('tests',))
['test', 'neomodel', 'test.test_contrib', 'neomodel.contrib']
>>> find_packages(exclude=('test',))
['neomodel', 'test.test_contrib', 'neomodel.contrib']
>>> find_packages(exclude=('test', 'test.*'))
['neomodel', 'neomodel.contrib']
```