### PR TITLE
Add a DateTimeFormatProperty which allows integrating with custom date format

### DIFF
--- a/doc/source/properties.rst
+++ b/doc/source/properties.rst
@@ -4,14 +4,15 @@ Property types
 
 The following properties are available on nodes and relationships:
 
-==============================================  ===========================================================
-:class:`~neomodel.properties.AliasProperty`     :class:`~neomodel.properties.IntegerProperty`
-:class:`~neomodel.properties.ArrayProperty`     :class:`~neomodel.properties.JSONProperty`
-:class:`~neomodel.properties.BooleanProperty`   :class:`~neomodel.properties.RegexProperty`
-:class:`~neomodel.properties.DateProperty`      :class:`~neomodel.properties.StringProperty`
-:class:`~neomodel.properties.DateTimeProperty`  :class:`~neomodel.properties.UniqueIdProperty`
-:class:`~neomodel.properties.FloatProperty`     :class:`~neomodel.contrib.spatial_properties.PointProperty`
-==============================================  ===========================================================
+====================================================  ===========================================================
+:class:`~neomodel.properties.AliasProperty`           :class:`~neomodel.properties.IntegerProperty`
+:class:`~neomodel.properties.ArrayProperty`           :class:`~neomodel.properties.JSONProperty`
+:class:`~neomodel.properties.BooleanProperty`         :class:`~neomodel.properties.RegexProperty`
+:class:`~neomodel.properties.DateProperty`            :class:`~neomodel.properties.StringProperty`
+:class:`~neomodel.properties.DateTimeProperty`        :class:`~neomodel.properties.UniqueIdProperty`
+:class:`~neomodel.properties.DateTimeFormatProperty`  :class:`~neomodel.contrib.spatial_properties.PointProperty`
+:class:`~neomodel.properties.FloatProperty`           \
+====================================================  ===========================================================
 
 
 Defaults
@@ -47,9 +48,7 @@ Array Properties
 ================
 Neomodel supports arrays via the `ArrayProperty` class and a list element type 
 can optionally be provided as the first argument::
-
-    class Person(StructuredNode):
-        names = ArrayProperty(StringProperty(), required=True)
+class Person(StructuredNode): names = ArrayProperty(StringProperty(), required=True)
 
     bob = Person(names=['bob', 'rob', 'robert']).save()
 
@@ -72,6 +71,13 @@ Dates and times
 The *DateTimeProperty* accepts `datetime.datetime` objects of any timezone and stores them as a UTC epoch value.
 These epoch values are inflated to datetime.datetime objects with the UTC timezone set.
 
+The *DateTimeFormatProperty* accepts `datetime.datetime` objects which are same as *DateTimeProperty* but stores them as a formatted date string.
+The date formatted pattern should be set by argument, default is "%Y-%m-%d".
+In the following example the datetime will be stored as 'YYYY-MM-DD HH:mm:ss'::
+      
+        created = DateTimeFormatProperty(format="%Y-%m-%d %H:%M:%S")
+
+
 The *DateProperty* accepts datetime.date objects which are stored as a string property 'YYYY-MM-DD'.
 
 The `default_now` parameter specifies the current time as the default value::
@@ -79,6 +85,7 @@ The `default_now` parameter specifies the current time as the default value::
         created = DateTimeProperty(default_now=True)
 
 Enforcing a specific timezone is done by setting the config variable` NEOMODEL_FORCE_TIMEZONE=1`.
+
 
 Other properties
 ================

--- a/doc/source/properties.rst
+++ b/doc/source/properties.rst
@@ -48,7 +48,9 @@ Array Properties
 ================
 Neomodel supports arrays via the `ArrayProperty` class and a list element type 
 can optionally be provided as the first argument::
-class Person(StructuredNode): names = ArrayProperty(StringProperty(), required=True)
+   
+    class Person(StructuredNode):
+        names = ArrayProperty(StringProperty(), required=True)
 
     bob = Person(names=['bob', 'rob', 'robert']).save()
 

--- a/neomodel/__init__.py
+++ b/neomodel/__init__.py
@@ -12,9 +12,11 @@ from neomodel.relationship_manager import (
 from .relationship import StructuredRel
 from .cardinality import (ZeroOrMore, OneOrMore, ZeroOrOne, One)
 from .properties import (StringProperty, IntegerProperty, AliasProperty,
-                         FloatProperty, BooleanProperty, DateTimeProperty, DateProperty,
-                         NormalizedProperty, RegexProperty, EmailProperty,
-                         JSONProperty, ArrayProperty, UniqueIdProperty)
+                         FloatProperty, BooleanProperty, 
+                         DateTimeFormatProperty, DateTimeProperty,
+                         DateProperty, NormalizedProperty, RegexProperty,
+                         EmailProperty, JSONProperty, ArrayProperty,
+                         UniqueIdProperty)
 
 __author__ = 'Robin Edwards'
 __email__ = 'robin.ge@gmail.com'

--- a/neomodel/properties.py
+++ b/neomodel/properties.py
@@ -433,6 +433,39 @@ class DateProperty(Property):
             raise ValueError(msg)
         return value.isoformat()
 
+class DateTimeFormatProperty(Property):
+    """
+    Store a datetime by custome format
+    :param default_now: If ``True``, the creation time (Local) will be used as default.
+                        Defaults to ``False``.
+    :param format:      Date format string, default is %Y-%m-%d
+
+    :type default_now:  :class:`bool`
+    :type format:       :class:`str`
+    """
+    form_field_class = 'DateFormatField'
+
+    def __init__(self, default_now=False, format="%Y-%m-%d", **kwargs):
+        if default_now:
+            if 'default' in kwargs:
+                raise ValueError('too many defaults')
+            kwargs['default'] = lambda: datetime.now()
+
+        self.format = format
+        super(DateTimeFormatProperty, self).__init__(**kwargs)
+
+    @validator
+    def inflate(self, value):
+        return datetime.strptime(unicode(value), self.format).date()
+
+    @validator
+    def deflate(self, value):
+        if not isinstance(value, datetime):
+            raise ValueError('datetime object expected, got {0}.'.format(type(value)))
+        return datetime.strftime(value, self.format)
+
+
+
 
 class DateTimeProperty(Property):
     """ A property representing a :class:`datetime.datetime` object as

--- a/neomodel/properties.py
+++ b/neomodel/properties.py
@@ -443,7 +443,7 @@ class DateTimeFormatProperty(Property):
     :type default_now:  :class:`bool`
     :type format:       :class:`str`
     """
-    form_field_class = 'DateFormatField'
+    form_field_class = 'DateTimeFormatField'
 
     def __init__(self, default_now=False, format="%Y-%m-%d", **kwargs):
         if default_now:
@@ -456,7 +456,7 @@ class DateTimeFormatProperty(Property):
 
     @validator
     def inflate(self, value):
-        return datetime.strptime(unicode(value), self.format).date()
+        return datetime.strptime(unicode(value), self.format)
 
     @validator
     def deflate(self, value):

--- a/test/test_properties.py
+++ b/test/test_properties.py
@@ -8,7 +8,7 @@ from neomodel.exceptions import InflateError, DeflateError
 from neomodel.properties import (
     ArrayProperty, IntegerProperty, DateProperty, DateTimeProperty,
     EmailProperty, JSONProperty, NormalProperty, NormalizedProperty,
-    RegexProperty, StringProperty, UniqueIdProperty
+    RegexProperty, StringProperty, UniqueIdProperty, DateTimeFormatProperty
 )
 from neomodel.util import _get_node_properties
 
@@ -78,6 +78,14 @@ def test_date():
     assert prop.deflate(somedate) == '2012-12-15'
     assert prop.inflate('2012-12-15') == somedate
 
+def test_datetime_format():
+    some_format = "%Y-%m-%d %H:%M:%S"
+    prop = DateTimeFormatProperty(format=some_format)
+    prop.name = 'foo'
+    prop.owner = FooBar
+    some_datetime = datetime(2019, 3, 19, 15, 36, 25)
+    assert prop.deflate(some_datetime) == '2019-03-19 15:36:25'
+    assert prop.inflate('2019-03-19 15:36:25') == some_datetime
 
 def test_datetime_exceptions():
     prop = DateTimeProperty()


### PR DESCRIPTION
Add a DateTimeFormatProperty so user can create a time property like that.
``` python
# In neo4j the property is like YYYY-mm-dd HH:MM:SS
some_format = "%Y-%m-%d %H:%M:%S"
timestamp = DateTimeFormatProperty(format=some_format)
```
Also add a test in test_properties.py to test the function.
