### PR TITLE
Add merge functionality

### DIFF
--- a/neomodel/core.py
+++ b/neomodel/core.py
@@ -553,14 +553,9 @@ class StructuredNode(NodeBase):
         properties = {attr: getattr(self.__class__, attr) for attr in dir(self.__class__)
                       if isinstance(getattr(self.__class__, attr), Property) and not attr.startswith("__")}
         primary_keys = [k for k, v in properties.items() if v.unique_index]
-        # assert len(primary_key) == 1
-        # primary_key = primary_key[0]
         property_keys = [k for k, v in properties.items() if not v.unique_index and k in deflated_params]
-        # query = f"MERGE (n:{':'.join(self.inherited_labels())} " \
-        #     f"{{{primary_key}: '{getattr(self, primary_key)}'}})\n"
-        query = f"MERGE (n:{':'.join(self.inherited_labels())} {{" \
-                + ", ".join([f"{Pkey}: '{deflated_params[Pkey]}'" for Pkey in primary_keys]) \
-                + "}})\n"
+        query = "MERGE (n:{0} {{".format(':'.join(self.inherited_labels()))
+        query += ", ".join(["{0}: '{1}'".format(Pkey, deflated_params[Pkey]) for Pkey in primary_keys]) + "}})\n"
         query += 'SET ' + ', '.join(
             ['n.' + pkey + '=\'' + deflated_params[pkey] + '\'' for pkey in property_keys]) + '\n' \
             if property_keys else ''


### PR DESCRIPTION
Completed the functionality described in #438 .
This StructureNode.merge() function allows users to create a node without worrying whether it is already in the graph or not.

e.g.

```python
class Article(StructuredNode):
    title = StringProperty(unique_index=True, required=True)
    param = StringProperty()
```
```python
article = Article(title='some title', param='value').merge()
```
This line is translate into Cypher as:
```Cypher
MERGE (a:Article {title: 'some title'})
SET a.param = 'value'
RETURN a
```
PLEASE NOTE: One and ONLY one unique index required.