### PR TITLE
testing for python3.7 and neo4j3.4

### DIFF
--- a/tests-with-docker-compose.sh
+++ b/tests-with-docker-compose.sh
@@ -46,8 +46,8 @@ for dir in neomodel test; do
     find ${dir} -name __pycache__ -exec rm -Rf {} \;
 done
 
-for NEO4J_VERSION in 3.0 3.1 3.2 3.3; do
-    for PYTHON_VERSION in 2.7 3.4 3.5 3.6; do
+for NEO4J_VERSION in 3.0 3.1 3.2 3.3 3.4; do
+    for PYTHON_VERSION in 3.5 3.6 3.7; do
         write_compose_file
         docker-compose up -d neo4j
         docker-compose up tests


### PR DESCRIPTION
Now the script `test-with-docker-compose.sh`:

* excludes: Python2.7 and Python3.4
* includes: Python3.7 and Neo4j-3.4

When running the script, tests are passing.

**Note**:
Including Neo4j-3.5 breaks some tests. I considere fixing these errors should be on a separate PR.
The full output can be found [here](https://gist.github.com/jvalhondo/f8d7717aaa088dfcda21fb17dcc20f01).