### PR TITLE
Correct inconsistent naming kls to cls

### DIFF
--- a/neomodel/core.py
+++ b/neomodel/core.py
@@ -114,8 +114,8 @@ def install_all_labels(stdout=None):
     if not stdout:
         stdout = sys.stdout
 
-    def subsub(kls):  # recursively return all subclasses
-        return kls.__subclasses__() + [g for s in kls.__subclasses__() for g in subsub(s)]
+    def subsub(cls):  # recursively return all subclasses
+        return cls.__subclasses__() + [g for s in cls.__subclasses__() for g in subsub(s)]
 
     stdout.write("Setting up indexes and constraints...\n\n")
 


### PR DESCRIPTION
Pretty sure that `cls` is universally used, `kls` doesn't seem to be used anywhere else in this library.