### PR TITLE
Feature: NodeSet.has filtering against a NodeSet

### DIFF
--- a/doc/source/queries.rst
+++ b/doc/source/queries.rst
@@ -128,6 +128,14 @@ The `has` method checks for existence of (one or more) relationships, in this ca
 
 This can be negated by setting `suppliers=False`, to find `Coffee` nodes without `suppliers`.
 
+Furthermore, `has` can check for a relationship to a specific set of nodes. For example, it is possible to find coffee
+that can be delivered for cheap, by passing a suppliers `NodeSet`::
+
+    Coffee.nodes.has(suppliers=Supplier.nodes.filter(delivery_cost__lt=2))
+
+The `has` function doesn't accept native python collections, only `NodeSet` or Boolean values. This is important
+because `all`, `get` and slicing (see following section) return a native collection and not a `NodeSet`.
+
 Iteration, slicing and more
 ===========================
 

--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -435,7 +435,7 @@ class QueryBuilder(object):
             query += ' WITH '
             query += self._ast['with']
 
-        query += ' RETURN ' + self._ast['return']
+        query += ' RETURN DISTINCT ' + self._ast['return']
 
         if 'order_by' in self._ast and self._ast['order_by']:
             query += ' ORDER BY '


### PR DESCRIPTION
NodeSet.has can accept a NodeSet value and filter the relationship against it, like so:
``` python
Person.nodes.has(pet=Pet.nodes.filter(name='kitty'))
```
NodeSet.has can accept a NodeSet that itself uses a NodeSet relationship filtering:
``` python
Person.nodes.has(
    child=Person.nodes.has(
        child=Person.nodes.filter(name='john')
    )
)
```

Node naming convention in QueryBuilder was modified - underscores in node names are duplicated as an escaping mechanism.