### PR TITLE
Updating deprecated method `search()` to `filter()`

### DIFF
--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -162,7 +162,7 @@ Working with relationships::
     len(germany.inhabitant) # 1
 
     # Find people called 'Jim' in germany
-    germany.inhabitant.search(name='Jim')
+    germany.inhabitant.filter(name='Jim')
 
     # Remove Jim's country relationship with Germany
     jim.country.disconnect(germany)


### PR DESCRIPTION
Responding to:
`DeprecationWarning: search() is now deprecated please use filter() and exclude()`