### PR TITLE
Add example of `exclude()`

### DIFF
--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -164,6 +164,9 @@ Working with relationships::
     # Find people called 'Jim' in germany
     germany.inhabitant.search(name='Jim')
 
+    # Find all the people called in germany except 'Jim'
+    germany.inhabitant.exclude(name='Jim')
+
     # Remove Jim's country relationship with Germany
     jim.country.disconnect(germany)
 


### PR DESCRIPTION
Responding to:
`DeprecationWarning: search() is now deprecated please use filter() and exclude()`