### PR TITLE
Fix the travis-ci build by replacing Oracle Java with Openjdk.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,10 @@ env:
   - NEO4J_VERSION="3.3.3"
   - NEO4J_VERSION="3.4.0"
 install:
-  - sudo apt-get update && sudo apt-get install oracle-java8-installer
+  - sudo add-apt-repository -y ppa:openjdk-r/ppa
+  - sudo apt-get update && sudo apt-get install openjdk-8-jre-headless
   - curl -L http://dist.neo4j.org/neo4j-community-$NEO4J_VERSION-unix.tar.gz | tar xz
 before_script:
-  - JAVA_HOME=/usr/lib/jvm/java-8-oracle neo4j-community-$NEO4J_VERSION/bin/neo4j start
+  - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 neo4j-community-$NEO4J_VERSION/bin/neo4j start
   - sleep 10
 script: "python setup.py test"


### PR DESCRIPTION
Travis CI builds have been failing for a while because Oracle Java 8 is no longer available.

This change switches the Travis builds to use OpenJDK instead.