### PR TITLE
Remove python 2.7 from ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 sudo: required
 python:
-  - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/neomodel/cardinality.py
+++ b/neomodel/cardinality.py
@@ -1,9 +1,7 @@
 from neomodel.exceptions import (
     AttemptedCardinalityViolation, CardinalityViolation
 )
-from neomodel.relationship_manager import (
-    RelationshipManager, ZeroOrMore
-)  #noqa: F401
+from neomodel.relationship_manager import RelationshipManager  # noqa: F401
 
 
 class ZeroOrOne(RelationshipManager):

--- a/neomodel/cardinality.py
+++ b/neomodel/cardinality.py
@@ -1,7 +1,5 @@
-from neomodel.exceptions import (
-    AttemptedCardinalityViolation, CardinalityViolation
-)
-from neomodel.relationship_manager import RelationshipManager  # noqa: F401
+from neomodel.exceptions import AttemptedCardinalityViolation, CardinalityViolation
+from neomodel.relationship_manager import RelationshipManager, ZeroOrMore  # noqa: F401
 
 
 class ZeroOrOne(RelationshipManager):

--- a/neomodel/core.py
+++ b/neomodel/core.py
@@ -97,9 +97,12 @@ def install_labels(cls, quiet=True, stdout=None):
                 stdout.write(' + Creating unique constraint for {0} on label {1} for class {2}.{3}\n'.format(
                     name, cls.__label__, cls.__module__, cls.__name__))
 
-            db.cypher_query("CREATE CONSTRAINT "
-                            "on (n:{0}) ASSERT n.{1} IS UNIQUE; ".format(
-                cls.__label__, db_property))
+            db.cypher_query(
+                "CREATE CONSTRAINT "
+                "on (n:{0}) ASSERT n.{1} IS UNIQUE; ".format(
+                    cls.__label__, db_property
+                )
+            )
 
 
 def install_all_labels(stdout=None):
@@ -260,7 +263,9 @@ class StructuredNode(NodeBase):
         query_params = dict(merge_params=merge_params)
         n_merge = "n:{0} {{{1}}}".format(
             ":".join(cls.inherited_labels()),
-            ", ".join("{0}: params.create.{0}".format(getattr(cls, p).db_property or p) for p in cls.__required_properties__))
+            ", ".join("{0}: params.create.{0}".format(
+                getattr(cls, p).db_property or p) for p in cls.__required_properties__)
+            )
         if relationship is None:
             # create "simple" unwind query
             query = "UNWIND {{merge_params}} as params\n MERGE ({0})\n ".format(n_merge)
@@ -296,8 +301,10 @@ class StructuredNode(NodeBase):
 
     @classmethod
     def category(cls):
-        raise NotImplementedError("Category was deprecated and has now been removed, "
-            "the functionality is now achieved using the {0}.nodes attribute".format(cls.__name__))
+        raise NotImplementedError(
+            "Category was deprecated and has now been removed, "
+            "the functionality is now achieved using the {0}.nodes attribute".format(cls.__name__)
+        )
 
     @classmethod
     def create(cls, *props, **kwargs):
@@ -499,8 +506,10 @@ class StructuredNode(NodeBase):
         """
         self._pre_action_check('refresh')
         if hasattr(self, 'id'):
-            request = self.cypher("MATCH (n) WHERE id(n)={self}"
-                                            " RETURN n")[0]
+            request = self.cypher(
+                "MATCH (n) WHERE id(n)={self}"
+                " RETURN n"
+            )[0]
             if not request or not request[0]:
                 raise self.__class__.DoesNotExist("Can't refresh non existent node")
             node = self.inflate(request[0][0])

--- a/neomodel/exceptions.py
+++ b/neomodel/exceptions.py
@@ -1,4 +1,3 @@
-import importlib
 
 
 class NeomodelException(Exception):

--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -386,7 +386,9 @@ class QueryBuilder(object):
                         statement = '{0} {1}.{2} {3}'.format('NOT' if negate else '', ident, prop, op)
                     else:
                         place_holder = self._register_place_holder(ident + '_' + prop)
-                        statement = '{0} {1}.{2} {3} {{{4}}}'.format('NOT' if negate else '', ident, prop, op, place_holder)
+                        statement = '{0} {1}.{2} {3} {{{4}}}'.format(
+                            'NOT' if negate else '', ident, prop, op, place_holder
+                        )
                         self._query_params[place_holder] = val
                     stmts.append(statement)
 
@@ -444,16 +446,16 @@ class QueryBuilder(object):
             # inject id = into ast
             self._ast['return'] = 'id({})'.format(self._ast['return'])
         query = self.build_query()
-        results, _ = db.cypher_query(query, self._query_params, resolve_objects=True)            
-        # The following is not as elegant as it could be but had to be copied from the 
+        results, _ = db.cypher_query(query, self._query_params, resolve_objects=True)
+        # The following is not as elegant as it could be but had to be copied from the
         # version prior to cypher_query with the resolve_objects capability.
-        # It seems that certain calls are only supposed to be focusing to the first 
+        # It seems that certain calls are only supposed to be focusing to the first
         # result item returned (?)
         if results:
             return [n[0] for n in results]
         return []
-        
-        
+
+
 class BaseSet(object):
     """
     Base class for all node sets.

--- a/neomodel/properties.py
+++ b/neomodel/properties.py
@@ -298,7 +298,7 @@ class StringProperty(NormalizedProperty):
         if max_length is not None:
             if choices is not None:
                 raise ValueError("The arguments `choices` and `max_length` are mutually exclusive.")
-            if max_length<1:
+            if max_length < 1:
                 raise ValueError("`max_length` cannot be zero or take negative values.")
 
         super(StringProperty, self).__init__(**kwargs)
@@ -320,8 +320,8 @@ class StringProperty(NormalizedProperty):
     def normalize(self, value):
         # One thing to note here is that the following two checks can remain uncoupled
         # as long as it is guaranteed (by the constructor) that `choices` and `max_length`
-        # are mutually exclusive. If that check in the constructor ever has to be removed, 
-        # these two validation checks here will have to be coupled so that having set 
+        # are mutually exclusive. If that check in the constructor ever has to be removed,
+        # these two validation checks here will have to be coupled so that having set
         # `choices` overrides having set the `max_length`.
         if self.choices is not None and value not in self.choices:
             raise ValueError("Invalid choice: {}".format(value))
@@ -452,6 +452,7 @@ class DateProperty(Property):
             raise ValueError(msg)
         return value.isoformat()
 
+
 class DateTimeFormatProperty(Property):
     """
     Store a datetime by custome format
@@ -482,8 +483,6 @@ class DateTimeFormatProperty(Property):
         if not isinstance(value, datetime):
             raise ValueError('datetime object expected, got {0}.'.format(type(value)))
         return datetime.strftime(value, self.format)
-
-
 
 
 class DateTimeProperty(Property):

--- a/neomodel/relationship.py
+++ b/neomodel/relationship.py
@@ -12,7 +12,7 @@ class RelationshipMeta(type):
                 value.name = key
                 value.owner = inst
                 if value.is_indexed:
-                    raise NotImplemented("Indexed relationship properties not supported yet")
+                    raise NotImplementedError("Indexed relationship properties not supported yet")
 
                 # support for 'magic' properties
                 if hasattr(value, 'setup') and hasattr(value.setup, '__call__'):
@@ -49,8 +49,10 @@ class StructuredRel(StructuredRelBase):
 
     @deprecated('This method will be removed in neomodel 4')
     def delete(self):
-        raise NotImplemented("Can not delete relationships please use"
-                             " 'disconnect'")
+        raise NotImplementedError(
+            "Can not delete relationships please use"
+            " 'disconnect'"
+        )
 
     def start_node(self):
         """
@@ -61,8 +63,8 @@ class StructuredRel(StructuredRelBase):
         return db.cypher_query("MATCH (aNode) "
                                "WHERE id(aNode)={nodeid} "
                                "RETURN aNode".format(nodeid=self._start_node_id),
-                               resolve_objects = True)[0][0][0]
-      
+                               resolve_objects=True)[0][0][0]
+
     def end_node(self):
         """
         Get end node
@@ -72,7 +74,7 @@ class StructuredRel(StructuredRelBase):
         return db.cypher_query("MATCH (aNode) "
                                "WHERE id(aNode)={nodeid} "
                                "RETURN aNode".format(nodeid=self._end_node_id),
-                               resolve_objects = True)[0][0][0]
+                               resolve_objects=True)[0][0][0]
 
     @classmethod
     def inflate(cls, rel):

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Topic :: Software Development :: Libraries :: Python Modules',
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
As mentioned here on the [README requirements section](https://github.com/neo4j-contrib/neomodel#requirements), Python 2.7 is supported up to version `3.3.1`.
Latest library release is version `3.3.2` so there is no need to include Python 2.7 in the CI process.

* Remove Python 2.7 from CI
* Also, remove Python 2.7 from `setup.py` classifier

**Note**: 
The CI process should include Python `3.7` and Python `3.8`, as requirements say Python `3.4+`.
That would be on a separate PR.