### PR TITLE
update CI and setup.py classifiers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 sudo: required
 python:
-  - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Topic :: Software Development :: Libraries :: Python Modules',
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
As mentioned here on the [README requirements section](https://github.com/neo4j-contrib/neomodel#requirements), Python `2.7` is supported up to version `3.3.1`.
Latest library release is version `3.3.2` so there is no need to include Python `2.7` in the CI process.

* Remove Python `2.7` from CI
* Also, remove Python `2.7` from `setup.py` classifier

**Note**:
The CI process should include Python `3.7` and Python `3.8`, as requirements section says Python `3.4+`.
That would be on a separate PR.

