### PR TITLE
Add support for slow query log

### DIFF
--- a/neomodel/util.py
+++ b/neomodel/util.py
@@ -243,8 +243,9 @@ class Database(local, NodeClassRegistry):
                                          retry_on_session_expire=False)
             raise
 
-        if os.environ.get('NEOMODEL_CYPHER_DEBUG', False):
-            logger.debug("query: " + query + "\nparams: " + repr(params) + "\ntook: {:.2g}s\n".format(end - start))
+        tte = (end - start)
+        if os.environ.get('NEOMODEL_CYPHER_DEBUG', False) and tte > float(os.environ.get('NEOMODEL_SLOW_QUERIES', 0)):
+            logger.debug("query: " + query + "\nparams: " + repr(params) + "\ntook: {:.2g}s\n".format(tte))
 
         return results, meta
 


### PR DESCRIPTION
This PR enhances the logging within the cypher_query method in ```neomodel.utils.py``` so that logging can be enabled only for queries that take longer than a specified amount of time. This is useful as the Neo4j query log is not available on the community edition and sometimes you only wish to log the slow queries and not everything especially if you are working on a production environment.

The logging uses a new optional environmental variable **NEOMODEL_SLOW_QUERIES** which can be set to a string whose value is thew threshold at which you want to start recording queries.

E.G If you set the value to the following ```os.environ["NEOMODEL_SLOW_QUERIES"] = "0.09"``` then only queries taking more than 0.09 seconds will be logged.

If the variable is not set, then it defaults to 0 and acts as before.