### PR TITLE
Initalise node_properties outside the for loop.

### DIFF
--- a/neomodel/contrib/semi_structured.py
+++ b/neomodel/contrib/semi_structured.py
@@ -32,9 +32,9 @@ class SemiStructuredNode(StructuredNode):
             snode = cls()
             snode.id = node
         else:
+            node_properties = _get_node_properties(node)
             props = {}
             for key, prop in cls.__all_properties__:
-                node_properties = _get_node_properties(node)
                 if key in node_properties:
                     props[key] = prop.inflate(node_properties[key], node)
                 elif prop.has_default:


### PR DESCRIPTION
Hello,

I encountered the problem while working with Neomodel. I think the change is OK, at least I could not see an obvious reason why the _get_node_properties(..) was inside the for loop.

Initalise node_properties outside the for loop so that it is initialised for the case where the first for loop is _not_ entered and the second for loop _is_ entered. In that case (when a SemiStructuredNode has no defined properties) an error would occur when calling save():

UnboundLocalError: local variable 'node_properties' referenced before assignment

... or a similar variation depending on your luck.

I've tested this (python 3.6) and noticed no change in unit test results. 