### PR TITLE
Fix #488

### DIFF
--- a/neomodel/core.py
+++ b/neomodel/core.py
@@ -263,7 +263,7 @@ class StructuredNode(NodeBase):
             ", ".join("{0}: params.create.{0}".format(getattr(cls, p).db_property or p) for p in cls.__required_properties__))
         if relationship is None:
             # create "simple" unwind query
-            query = "UNWIND {{merge_params}} as params\n MERGE ({0})\n ".format(n_merge)
+            query = "UNWIND $merge_params as params\n MERGE ({0})\n ".format(n_merge)
         else:
             # validate relationship
             if not isinstance(relationship.source, StructuredNode):
@@ -275,8 +275,8 @@ class StructuredNode(NodeBase):
             from .match import _rel_helper
 
             query_params["source_id"] = relationship.source.id
-            query = "MATCH (source:{0}) WHERE ID(source) = {{source_id}}\n ".format(relationship.source.__label__)
-            query += "WITH source\n UNWIND {merge_params} as params \n "
+            query = "MATCH (source:{0}) WHERE ID(source) = $source_id\n ".format(relationship.source.__label__)
+            query += "WITH source\n UNWIND $merge_params as params \n "
             query += "MERGE "
             query += _rel_helper(lhs='source', rhs=n_merge, ident=None,
                                  relation_type=relation_type, direction=relationship.definition['direction'])
@@ -317,7 +317,7 @@ class StructuredNode(NodeBase):
 
         lazy = kwargs.get('lazy', False)
         # create mapped query
-        query = "CREATE (n:{0} {{create_params}})".format(':'.join(cls.inherited_labels()))
+        query = "CREATE (n:{0} $create_params)".format(':'.join(cls.inherited_labels()))
 
         # close query
         if lazy:
@@ -395,7 +395,7 @@ class StructuredNode(NodeBase):
         :return: True
         """
         self._pre_action_check('delete')
-        self.cypher("MATCH (self) WHERE id(self)={self} "
+        self.cypher("MATCH (self) WHERE id(self)=$self "
                     "OPTIONAL MATCH (self)-[r]-()"
                     " DELETE r, self")
         delattr(self, 'id')
@@ -482,7 +482,7 @@ class StructuredNode(NodeBase):
         :rtype: list
         """
         self._pre_action_check('labels')
-        return self.cypher("MATCH (n) WHERE id(n)={self} "
+        return self.cypher("MATCH (n) WHERE id(n)=$self "
                            "RETURN labels(n)")[0][0][0]
 
     def _pre_action_check(self, action):
@@ -499,7 +499,7 @@ class StructuredNode(NodeBase):
         """
         self._pre_action_check('refresh')
         if hasattr(self, 'id'):
-            request = self.cypher("MATCH (n) WHERE id(n)={self}"
+            request = self.cypher("MATCH (n) WHERE id(n)=$self"
                                             " RETURN n")[0]
             if not request or not request[0]:
                 raise self.__class__.DoesNotExist("Can't refresh non existent node")
@@ -521,9 +521,8 @@ class StructuredNode(NodeBase):
         if hasattr(self, 'id'):
             # update
             params = self.deflate(self.__properties__, self)
-            query = "MATCH (n) WHERE id(n)={self} \n"
-            query += "\n".join(["SET n.{0} = {{{1}}}".format(key, key) + "\n"
-                                for key in params.keys()])
+            query = "MATCH (n) WHERE id(n)=$self \n"
+            query += "\n".join(["SET n.{0} = ${1}".format(key, key) + "\n" for key in params.keys()])
             for label in self.inherited_labels():
                 query += "SET n:`{0}`\n".format(label)
             self.cypher(query, params)

--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -61,6 +61,55 @@ def _rel_helper(lhs, rhs, ident=None, relation_type=None, direction=None, relati
     return "({0}){1}({2})".format(lhs, stmt, rhs)
 
 
+def _rel_merge_helper(lhs, rhs, ident='neomodelident', relation_type=None, direction=None, relation_properties=None, **kwargs):
+    """
+    Generate a relationship merging string, with specified parameters.
+    Examples:
+    relation_direction = OUTGOING: (lhs)-[relation_ident:relation_type]->(rhs)
+    relation_direction = INCOMING: (lhs)<-[relation_ident:relation_type]-(rhs)
+    relation_direction = EITHER: (lhs)-[relation_ident:relation_type]-(rhs)
+
+    :param lhs: The left hand statement.
+    :type lhs: str
+    :param rhs: The right hand statement.
+    :type rhs: str
+    :param ident: A specific identity to name the relationship, or None.
+    :type ident: str
+    :param relation_type: None for all direct rels, * for all of any length, or a name of an explicit rel.
+    :type relation_type: str
+    :param direction: None or EITHER for all OUTGOING,INCOMING,EITHER. Otherwise OUTGOING or INCOMING.
+    :param relation_properties: dictionary of relationship properties to merge
+    :returns: string
+    """
+
+    if direction == OUTGOING:
+        stmt = '-{0}->'
+    elif direction == INCOMING:
+        stmt = '<-{0}-'
+    else:
+        stmt = '-{0}-'
+
+    rel_props = ''
+
+    if relation_properties:
+        rel_props = ' ON CREATE SET {0} ON MATCH SET {0}'.format(
+            '{0}.{1}'.format(ident, ', '.join(
+                ['{0}={1}'.format(key, value) for key, value in relation_properties.items()]))
+        )
+
+    # direct, relation_type=None is unspecified, relation_type
+    if relation_type is None:
+        stmt = stmt.format('')
+    # all("*" wildcard) relation_type
+    elif relation_type == '*':
+        stmt = stmt.format('[*]')
+    else:
+        # explicit relation_type
+        stmt = stmt.format('[{0}:`{1}`]'.format(ident, relation_type))
+
+    return "({0}){1}({2}){3}".format(lhs, stmt, rhs, rel_props)
+
+
 # special operators
 _SPECIAL_OPERATOR_IN = 'IN'
 _SPECIAL_OPERATOR_INSENSITIVE = '(?i)'

--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -287,7 +287,7 @@ class QueryBuilder(object):
         place_holder = self._register_place_holder(ident)
 
         # Hack to emulate START to lookup a node by id
-        _node_lookup = 'MATCH ({0}) WHERE id({1})={{{2}}} WITH {3}'.format(ident, ident, place_holder, ident)
+        _node_lookup = 'MATCH ({0}) WHERE id({1})=${2} WITH {3}'.format(ident, ident, place_holder, ident)
         self._ast['lookup'] = _node_lookup
 
         self._query_params[place_holder] = node.id
@@ -353,7 +353,7 @@ class QueryBuilder(object):
                         statement = '{0}.{1} {2}'.format(ident, prop, op)
                     else:
                         place_holder = self._register_place_holder(ident + '_' + prop)
-                        statement = '{0}.{1} {2} {{{3}}}'.format(ident, prop, op, place_holder)
+                        statement = '{0}.{1} {2} ${3}'.format(ident, prop, op, place_holder)
                         self._query_params[place_holder] = val
                     target.append(statement)
         ret = ' {0} '.format(q.connector).join(target)
@@ -386,7 +386,7 @@ class QueryBuilder(object):
                         statement = '{0} {1}.{2} {3}'.format('NOT' if negate else '', ident, prop, op)
                     else:
                         place_holder = self._register_place_holder(ident + '_' + prop)
-                        statement = '{0} {1}.{2} {3} {{{4}}}'.format('NOT' if negate else '', ident, prop, op, place_holder)
+                        statement = '{0} {1}.{2} {3} ${4}'.format('NOT' if negate else '', ident, prop, op, place_holder)
                         self._query_params[place_holder] = val
                     stmts.append(statement)
 
@@ -435,7 +435,7 @@ class QueryBuilder(object):
         # inject id = into ast
         ident = self._ast['return']
         place_holder = self._register_place_holder(ident + '_contains')
-        self._ast['where'].append('id({0}) = {{{1}}}'.format(ident, place_holder))
+        self._ast['where'].append('id({0}) = ${1}'.format(ident, place_holder))
         self._query_params[place_holder] = node_id
         return self._count() >= 1
 

--- a/neomodel/properties.py
+++ b/neomodel/properties.py
@@ -511,6 +511,9 @@ class DateTimeProperty(Property):
         except ValueError:
             raise ValueError("Float or integer expected, got {0} can't inflate to "
                              "datetime.".format(type(value)))
+        except TypeError:
+            raise TypeError(
+                "Float or integer expected. Can't inflate {0} to datetime.".format(type(value)))
         return datetime.utcfromtimestamp(epoch).replace(tzinfo=pytz.utc)
 
     @validator

--- a/neomodel/relationship.py
+++ b/neomodel/relationship.py
@@ -38,9 +38,9 @@ class StructuredRel(StructuredRelBase):
         :return: self
         """
         props = self.deflate(self.__properties__)
-        query = "MATCH ()-[r]->() WHERE id(r)={self} "
+        query = "MATCH ()-[r]->() WHERE id(r)=$self "
         for key in props:
-            query += " SET r.{0} = {{{1}}}".format(key, key)
+            query += " SET r.{0} = ${1}".format(key, key)
         props['self'] = self.id
 
         db.cypher_query(query, props)
@@ -59,7 +59,7 @@ class StructuredRel(StructuredRelBase):
         :return: StructuredNode
         """
         return db.cypher_query("MATCH (aNode) "
-                               "WHERE id(aNode)={nodeid} "
+                               "WHERE id(aNode)=$nodeid "
                                "RETURN aNode".format(nodeid=self._start_node_id),
                                resolve_objects = True)[0][0][0]
       
@@ -70,7 +70,7 @@ class StructuredRel(StructuredRelBase):
         :return: StructuredNode
         """
         return db.cypher_query("MATCH (aNode) "
-                               "WHERE id(aNode)={nodeid} "
+                               "WHERE id(aNode)=$nodeid "
                                "RETURN aNode".format(nodeid=self._end_node_id),
                                resolve_objects = True)[0][0][0]
 

--- a/neomodel/relationship.py
+++ b/neomodel/relationship.py
@@ -59,7 +59,7 @@ class StructuredRel(StructuredRelBase):
         :return: StructuredNode
         """
         return db.cypher_query("MATCH (aNode) "
-                               "WHERE id(aNode)=$nodeid "
+                               "WHERE id(aNode)={nodeid} "
                                "RETURN aNode".format(nodeid=self._start_node_id),
                                resolve_objects = True)[0][0][0]
       
@@ -70,7 +70,7 @@ class StructuredRel(StructuredRelBase):
         :return: StructuredNode
         """
         return db.cypher_query("MATCH (aNode) "
-                               "WHERE id(aNode)=$nodeid "
+                               "WHERE id(aNode)={nodeid} "
                                "RETURN aNode".format(nodeid=self._end_node_id),
                                resolve_objects = True)[0][0][0]
 

--- a/neomodel/relationship_manager.py
+++ b/neomodel/relationship_manager.py
@@ -83,14 +83,14 @@ class RelationshipManager(object):
             tmp = rel_model(**properties) if properties else rel_model()
             # build params and place holders to pass to rel_helper
             for p, v in rel_model.deflate(tmp.__properties__).items():
-                rp[p] = '{' + p + '}'
+                rp[p] = '$' + p
                 params[p] = v
 
             if hasattr(tmp, 'pre_save'):
                 tmp.pre_save()
 
         new_rel = _rel_helper(lhs='us', rhs='them', ident='r', relation_properties=rp, **self.definition)
-        q = "MATCH (them), (us) WHERE id(them)={them} and id(us)={self} " \
+        q = "MATCH (them), (us) WHERE id(them)=$them and id(us)=$self " \
             "CREATE UNIQUE" + new_rel
 
         params['them'] = node.id
@@ -130,7 +130,7 @@ class RelationshipManager(object):
         """
         self._check_node(node)
         my_rel = _rel_helper(lhs='us', rhs='them', ident='r', **self.definition)
-        q = "MATCH " + my_rel + " WHERE id(them)={them} and id(us)={self} RETURN r LIMIT 1"
+        q = "MATCH " + my_rel + " WHERE id(them)=$them and id(us)=$self RETURN r LIMIT 1"
         rels = self.source.cypher(q, {'them': node.id})[0]
         if not rels:
             return
@@ -150,7 +150,7 @@ class RelationshipManager(object):
         self._check_node(node)
 
         my_rel = _rel_helper(lhs='us', rhs='them', ident='r', **self.definition)
-        q = "MATCH " + my_rel + " WHERE id(them)={them} and id(us)={self} RETURN r "
+        q = "MATCH " + my_rel + " WHERE id(them)=$them and id(us)=$self RETURN r "
         rels = self.source.cypher(q, {'them': node.id})[0]
         if not rels:
             return []
@@ -187,7 +187,7 @@ class RelationshipManager(object):
 
         # get list of properties on the existing rel
         result, meta = self.source.cypher(
-            "MATCH (us), (old) WHERE id(us)={self} and id(old)={old} "
+            "MATCH (us), (old) WHERE id(us)=$self and id(old)=$old "
             "MATCH " + old_rel + " RETURN r", {'old': old_node.id})
         if result:
             node_properties = _get_node_properties(result[0][0])
@@ -198,7 +198,7 @@ class RelationshipManager(object):
         # remove old relationship and create new one
         new_rel = _rel_helper(lhs='us', rhs='new', ident='r2', **self.definition)
         q = "MATCH (us), (old), (new) " \
-            "WHERE id(us)={self} and id(old)={old} and id(new)={new} " \
+            "WHERE id(us)=$self and id(old)=$old and id(new)=$new " \
             "MATCH " + old_rel
         q += " CREATE UNIQUE" + new_rel
 
@@ -218,7 +218,7 @@ class RelationshipManager(object):
         :return:
         """
         rel = _rel_helper(lhs='a', rhs='b', ident='r', **self.definition)
-        q = "MATCH (a), (b) WHERE id(a)={self} and id(b)={them} " \
+        q = "MATCH (a), (b) WHERE id(a)=$self and id(b)=$them " \
             "MATCH " + rel + " DELETE r"
         self.source.cypher(q, {'them': node.id})
 
@@ -231,7 +231,7 @@ class RelationshipManager(object):
         """
         rhs = 'b:' + self.definition['node_class'].__label__
         rel = _rel_helper(lhs='a', rhs=rhs, ident='r', **self.definition)
-        q = 'MATCH (a) WHERE id(a)={self} MATCH ' + rel + ' DELETE r'
+        q = 'MATCH (a) WHERE id(a)=$self MATCH ' + rel + ' DELETE r'
         self.source.cypher(q)
 
     @check_source

--- a/neomodel/util.py
+++ b/neomodel/util.py
@@ -36,7 +36,7 @@ def ensure_connection(func):
 
 
 def change_neo4j_password(db, new_password):
-    db.cypher_query("CALL dbms.changePassword({password})", {'password': new_password})
+    db.cypher_query("CALL dbms.changePassword($password)", {'password': new_password})
 
 
 def clear_neo4j_database(db):


### PR DESCRIPTION
**This depends entirely on #490 ** as it cannot function without parameters working. The same 2 commits from that branch are also included here. Made as a separate pull request, to allow cherry picking.
**This will likely need a documentation update** since MERGE behaves differently than CREATE UNIQUE did. That said, by utilizing MERGE and ON CREATE + ON MATCH, it should behave similarly. This was all done by making a new function (_rel_merge_helper) in match.py, to ensure that the usage of the regular _rel_helper function is not marred by this.