### PR TITLE
Fix #489

### DIFF
--- a/neomodel/contrib/spatial_properties.py
+++ b/neomodel/contrib/spatial_properties.py
@@ -21,7 +21,6 @@
 
 __author__ = "Athanasios Anastasiou"
 
-import neo4j.v1
 import neo4j.types.spatial
 
 # If shapely is not installed, its import will fail and the spatial properties will not be available

--- a/neomodel/util.py
+++ b/neomodel/util.py
@@ -5,7 +5,7 @@ import time
 import warnings
 from threading import local
 
-from neo4j.v1 import GraphDatabase, basic_auth, CypherError, SessionError
+from neo4j import GraphDatabase, basic_auth, CypherError, SessionError
 from neo4j.types.graph import Node
 
 from . import config


### PR DESCRIPTION
Changed to importing from neo4j instead of neo4j.v1 in accordance with https://neo4j.com/docs/api/python-driver/current/. This fixes #489.
Removed import neo4j from spatial_properties.py, as it is not used.

No changes seemed necessary compared to running with neo4j.v1.