### PR TITLE
Add support for Q objects on relationship_manager.filter and .exclude

### DIFF
--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -649,6 +649,10 @@ class NodeSet(BaseSet):
         """
         Apply filters to the existing nodes in the set.
 
+        :param args: a Q object
+
+            e.g `.filter(Q(salary__lt=10000) | Q(salary__gt=20000))`.
+
         :param kwargs: filter parameters
 
             Filters mimic Django's syntax with the double '__' to separate field and operators.

--- a/neomodel/relationship_manager.py
+++ b/neomodel/relationship_manager.py
@@ -270,14 +270,15 @@ class RelationshipManager(object):
         """
         return self.filter(**kwargs).all()
 
-    def filter(self, **kwargs):
+    def filter(self, *args, **kwargs):
         """
         Retrieve related nodes matching the provided properties.
 
+        :param args: a Q object
         :param kwargs: same syntax as `NodeSet.filter()`
         :return: NodeSet
         """
-        return NodeSet(self._new_traversal()).filter(**kwargs)
+        return NodeSet(self._new_traversal()).filter(*args, **kwargs)
 
     def order_by(self, *props):
         """
@@ -288,14 +289,15 @@ class RelationshipManager(object):
         """
         return NodeSet(self._new_traversal()).order_by(*props)
 
-    def exclude(self, **kwargs):
+    def exclude(self, *args, **kwargs):
         """
         Exclude nodes that match the provided properties.
 
+        :param args: a Q object
         :param kwargs: same syntax as `NodeSet.filter()`
         :return: NodeSet
         """
-        return NodeSet(self._new_traversal()).exclude(**kwargs)
+        return NodeSet(self._new_traversal()).exclude(*args, **kwargs)
 
     def is_connected(self, node):
         """

--- a/test/test_relationships.py
+++ b/test/test_relationships.py
@@ -1,8 +1,7 @@
 from pytest import raises
 
 from neomodel import (StructuredNode, RelationshipTo, RelationshipFrom, Relationship,
-                      StringProperty, IntegerProperty, StructuredRel, One)
-
+                      StringProperty, IntegerProperty, StructuredRel, One, Q)
 
 class PersonWithRels(StructuredNode):
     name = StringProperty(unique_index=True)
@@ -106,11 +105,17 @@ def test_search_and_filter_and_exclude():
     result = fred.is_from.filter(code='ZX')
     assert result[0].code == 'ZX'
 
-    result = fred.is_from.filter(code='ZX')
-    assert result[0].code == 'ZX'
+    result = fred.is_from.filter(code='ZY')
+    assert result[0].code == 'ZY'
 
     result = fred.is_from.exclude(code='ZZ').exclude(code='ZY')
     assert result[0].code == 'ZX' and len(result) == 1
+
+    result = fred.is_from.exclude(Q(code__contains='Y'))
+    assert len(result) == 2
+
+    result = fred.is_from.filter(Q(code__contains='Z'))
+    assert len(result) == 3
 
 
 def test_custom_methods():


### PR DESCRIPTION
As of 3.3.2, it is not possible to do `Person.friends.filter(Q(age__lt=25) | Q(name__exact="John"))` (it raises a `TypeError`).
This PR should make it possible.