### PR TITLE
Multiple label relation traversal

### DIFF
--- a/doc/source/relationships.rst
+++ b/doc/source/relationships.rst
@@ -173,5 +173,8 @@ The ``defintion`` argument is a :term:`py3:mapping` with these items:
 ``direction``      ``match.OUTGOING`` / ``match.INCOMING`` / ``match.EITHER``
 ``relation_type``  Can be ``None`` (for any direction), ``*`` for all paths
                    or an explicit name of a relation type (the edge's label).
+                   Matching multiple labels can be done by supplying a list of
+                   names. This will match any edge that matches at least one of
+                   these.
 ``model``          The class of the relation model, ``None`` for such without one.
 =================  ===============================================================

--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -485,7 +485,7 @@ class QueryBuilder(object):
         return query
 
     def _count(self):
-        self._ast['return'] = 'count({0})'.format(self._ast['return'])
+        self._ast['return'] = 'count({0} {1})'.format(self._ast.pop('return_mod', ''), self._ast['return'])
         # drop order_by, results in an invalid query
         self._ast.pop('order_by', None)
         query = self.build_query()

--- a/test/test_relationships.py
+++ b/test/test_relationships.py
@@ -205,12 +205,10 @@ def test_multiple_label_relationship_traversal():
     relations_traversal = Traversal(c1, PersonWithRels.__label__,
                                     definition)
 
-    inhabitants_and_prez = relations_traversal.all()
+    assert len(relations_traversal) == 2
 
-    assert len(inhabitants_and_prez) == 2
-
-    assert p1 in inhabitants_and_prez
-    assert p2 in inhabitants_and_prez
+    assert p1 in relations_traversal
+    assert p2 in relations_traversal
 
     # add president as inhabitant
     c1.inhabitant.connect(p2)
@@ -219,10 +217,16 @@ def test_multiple_label_relationship_traversal():
     relations_traversal = Traversal(c1, PersonWithRels.__label__,
                                     definition)
 
-    inhabitants_and_prez = relations_traversal.all()
-
     # p2 is connected twice, but should only be returned once
-    assert len(inhabitants_and_prez) == 2
+    assert len(relations_traversal) == 2
 
-    assert p1 in inhabitants_and_prez
-    assert p2 in inhabitants_and_prez
+    assert p1 in relations_traversal
+    assert p2 in relations_traversal
+
+    # check if lazy evaluation also honors the distinct restriction
+    lazy_evaluated = Traversal(c1, PersonWithRels.__label__, definition).all(True)
+
+    assert len(lazy_evaluated) == 2
+
+    assert p1.id in lazy_evaluated
+    assert p2.id in lazy_evaluated


### PR DESCRIPTION
As per #533 I added support for multiple relation labels in relationship traversal. It's used like this:

```python
definition = dict(node_class=Person, direction=INCOMING,
                  relation_type=('FATHER','MOTHER'), model=None)
relations_traversal = Traversal(jim, Person.__label__,
                                definition)
all_jims_children = relations_traversal.all()
```

I had to add support for `DISTINCT` modifiers to return statements. I am not sure, how this would be done best. I tried to modify the `_ast['return']` field, but this was used in a lot of places and broke a few things. I then introduced a new field `_ast['return_mod']` which is then added to the query like this:

```python
query += ' RETURN ' + self._ast.get('return_mod', '') + ' ' + self._ast['return']
```

Furthermore we need to consider it's impact in the `_count`, `_contains` and `_execute` methods: 

* `_contains` just introduces a new constraint that matches a single item, the distinct modifier does not make any difference here.
* `_execute` wraps the `_ast['return']` in an `id()` call. If we want unique results, we keep the modifier
* `_count` requires the most rework. Here we need to pull the modifier into the `count()` call.

I believe I cover all this in the test I wrote, but a critical eye would be highly appreciated (it's the first python unit test for me)
