### PR TITLE
Add support for multi databases

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -6,7 +6,7 @@ This section is covering the Neomodel 'config' module and its variables.
 Database
 --------
 
-Seting the connection URL::
+Setting the connection URL::
 
     config.DATABASE_URL = 'bolt://neo4j:neo4j@localhost:7687`
 
@@ -18,6 +18,10 @@ Adjust connection pool size::
 
     config.MAX_CONNECTION_POOL_SIZE = 50  # default
 
+Setting the database name, for neo4j >= 4::
+
+    config.DATABASE_URL = 'bolt://neo4j:neo4j@localhost:7687/mydb`
+
 Enable automatic index and constraint creation
 ----------------------------------------------
 
@@ -28,7 +32,7 @@ constraints and indexes at compile time. However this method is only recommended
     # before loading your node definitions
     config.AUTO_INSTALL_LABELS = True
 
-Neomodel also provides the `neomodel_install_labels` scripr for this task, 
+Neomodel also provides the `neomodel_install_labels` script for this task,
 however if you want to handle this manually see below.
 
 Install indexes and constraints for a single class::

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -10,6 +10,8 @@ Before executing any neomodel code, set the connection url::
     from neomodel import config
     config.DATABASE_URL = 'bolt://neo4j:neo4j@localhost:7687'  # default
 
+    # You can specify a database name: 'bolt://neo4j:neo4j@localhost:7687/mydb'
+
 This must be called early on in your app, if you are using Django the `settings.py` file is ideal.
 
 If you are using your neo4j server for the first time you will need to change the default password.


### PR DESCRIPTION
Resolve https://github.com/neo4j-contrib/neomodel/issues/526

Driver database documentation: https://neo4j.com/docs/api/python-driver/4.1/api.html#database

With this PR, we can specify the database name in the neo4j or bolr URL:

`bolt://neo4j:neo4j@localhost:7687` => default database
`bolt://neo4j:neo4j@localhost:7687/mydb` => `mydb` database
