### PR TITLE
Fix spelling in batch.rst

### DIFF
--- a/doc/source/batch.rst
+++ b/doc/source/batch.rst
@@ -39,7 +39,7 @@ Atomically create or update nodes in a single operation::
 This is useful for ensuring data is up to date, each node is matched by its required and/or unique properties. Any
 additional properties will be set on a newly created or an existing node.
 
-It is important to provide unique identifiers were known, any fields with default values that are omitted will be generated.
+It is important to provide unique identifiers where known, any fields with default values that are omitted will be generated.
 
 get_or_create()
 ---------------


### PR DESCRIPTION
Updates `were` to `where`

<img width="687" alt="Screen Shot 2021-08-26 at 15 27 42" src="https://user-images.githubusercontent.com/7830949/131031595-773818d5-9161-4331-8e05-e52a680193f9.png">
