### PR TITLE
Update transactions.rst to fix spelling

### DIFF
--- a/doc/source/transactions.rst
+++ b/doc/source/transactions.rst
@@ -48,7 +48,7 @@ If you're using celery or another task scheduler it's advised to wrap each task 
 Explicit Transactions
 ---------------------
 
-Neomodel also supports  `epxlicit transactions <https://neo4j.com/docs/
+Neomodel also supports  `explicit transactions <https://neo4j.com/docs/
 api/python-driver/current/transactions.html>`_ that are pre-designated as either *read* or *write*. 
 
 This is vital when using neomodel over a `Neo4J causal cluster <https://neo4j.com/docs/


### PR DESCRIPTION
Updates `epxlicit` to `explicit`

<img width="679" alt="Screen Shot 2021-08-26 at 15 31 02" src="https://user-images.githubusercontent.com/7830949/131031964-20240f23-8cb9-44af-9069-dfd19e502cbc.png">
