### PR TITLE
Fix DateProperty inflate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ development.env
 .ropeproject
 \#*\#
 .eggs
+bin
+lib
+.vscode
+pyvenv.cfg

--- a/neomodel/properties.py
+++ b/neomodel/properties.py
@@ -443,7 +443,7 @@ class DateProperty(Property):
 
     @validator
     def inflate(self, value):
-        return datetime.strptime(unicode(value), "%Y-%m-%d").date()
+        return datetime.fromisoformat(unicode(value)).date()
 
     @validator
     def deflate(self, value):

--- a/neomodel/properties.py
+++ b/neomodel/properties.py
@@ -9,6 +9,8 @@ from datetime import date, datetime
 
 import pytz
 
+import neo4j.time
+
 from neomodel import config
 from neomodel.exceptions import InflateError, DeflateError, RequiredProperty
 
@@ -443,7 +445,12 @@ class DateProperty(Property):
 
     @validator
     def inflate(self, value):
-        return datetime.fromisoformat(unicode(value)).date()
+        if isinstance(value, neo4j.time.DateTime):
+            value = date(value.year, value.month, value.day)
+        elif isinstance(value, str):
+            if "T" in value:
+                value = value[:value.find('T')]
+        return datetime.strptime(unicode(value), "%Y-%m-%d").date()
 
     @validator
     def deflate(self, value):

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -1,8 +1,9 @@
 from __future__ import print_function
 
+from datetime import datetime
 from pytest import raises
 
-from neomodel import StructuredNode, StringProperty, IntegerProperty
+from neomodel import DateProperty, StructuredNode, StringProperty, IntegerProperty
 from neomodel.exceptions import RequiredProperty, UniqueProperty
 
 
@@ -245,3 +246,10 @@ def test_mixins():
     assert len(jim.inherited_labels()) == 1
     assert len(jim.labels()) == 1
     assert jim.labels()[0] == 'Shopper2'
+
+def test_date_property():
+    class DateTest(StructuredNode):
+        birthdate = DateProperty()
+    
+    user = DateTest(birthdate=datetime.now()).save()
+


### PR DESCRIPTION
`DateProperty` requires `datetime` data type and in `deflate()` it's converted to isoformat of view `YYYY-MM-DDTHH:MM:SS`. Then `inflate()` tries to convert it back to `datetime` by using `strptime(.., "%Y-%m-%d")`, which doesn't deal with 'THH:MM:SS'. Python since 3.7 has `fromisoformat()`, which is a counterpart for `isoformat()`.