### PR TITLE
Use modern python API for metadata

### DIFF
--- a/neomodel/__init__.py
+++ b/neomodel/__init__.py
@@ -22,4 +22,12 @@ __author__ = 'Robin Edwards'
 __email__ = 'robin.ge@gmail.com'
 __license__ = 'MIT'
 __package__ = 'neomodel'
-__version__ = pkg_resources.get_distribution('neomodel').version
+if (sys.version_info.major, sys.version_info.minor) >= (3, 8)
+    from importlib.metadata import version
+    neo_version = version("neomodel")
+else:
+    import pkg_resources
+    neo_version = pkg_resources.get_distribution('neomodel').version
+
+__version__ = neo_version
+

--- a/neomodel/__init__.py
+++ b/neomodel/__init__.py
@@ -22,7 +22,7 @@ __author__ = 'Robin Edwards'
 __email__ = 'robin.ge@gmail.com'
 __license__ = 'MIT'
 __package__ = 'neomodel'
-if (sys.version_info.major, sys.version_info.minor) >= (3, 8)
+if (sys.version_info.major, sys.version_info.minor) >= (3, 8):
     from importlib.metadata import version
     neo_version = version("neomodel")
 else:


### PR DESCRIPTION
Ref: https://docs.python.org/3.9/library/importlib.metadata.html#module-importlib.metadata

Ref: https://github.com/googleapis/python-api-core/issues/27#issuecomment-676563754
(@pganssle is CPython Core Dev. :))

pkg_resources is causing a few issues for us, particularly in lambda envs

This is a much better way in Python 3.8+

cc @whatSocks @nossila 