### PR TITLE
Ensure compatibility after neo4j 4.4 update

### DIFF
--- a/neomodel/core.py
+++ b/neomodel/core.py
@@ -110,8 +110,8 @@ def install_labels(cls, quiet=True, stdout=None):
                 db.cypher_query("CREATE INDEX on :{0}({1}); ".format(
                     cls.__label__, db_property))
             except ClientError as e:
-                if e.code in ('Neo.ClientError.Schema.IndexAlreadyExists',
-                              'Neo.ClientError.Schema.EquivalentSchemaRuleAlreadyExists'):
+                if e.code in ('Neo.ClientError.Schema.EquivalentSchemaRuleAlreadyExists',
+                              'Neo.ClientError.Schema.IndexAlreadyExists'):
                     stdout.write('{0}\n'.format(str(e)))
                 else:
                     raise
@@ -125,8 +125,8 @@ def install_labels(cls, quiet=True, stdout=None):
                                 "on (n:{0}) ASSERT n.{1} IS UNIQUE".format(
                     cls.__label__, db_property))
             except ClientError as e:
-                if e.code in ('Neo.ClientError.Schema.ConstraintAlreadyExists',
-                              'Neo.ClientError.Schema.EquivalentSchemaRuleAlreadyExists'):
+                if e.code in ('Neo.ClientError.Schema.EquivalentSchemaRuleAlreadyExists',
+                              'Neo.ClientError.Schema.ConstraintAlreadyExists'):
                     stdout.write('{0}\n'.format(str(e)))
                 else:
                     raise

--- a/neomodel/core.py
+++ b/neomodel/core.py
@@ -110,7 +110,8 @@ def install_labels(cls, quiet=True, stdout=None):
                 db.cypher_query("CREATE INDEX on :{0}({1}); ".format(
                     cls.__label__, db_property))
             except ClientError as e:
-                if str(e.message).lower().startswith("an equivalent index already exists"):
+                if e.code in ('Neo.ClientError.Schema.IndexAlreadyExists',
+                              'Neo.ClientError.Schema.EquivalentSchemaRuleAlreadyExists'):
                     stdout.write('{0}\n'.format(str(e)))
                 else:
                     raise
@@ -124,7 +125,8 @@ def install_labels(cls, quiet=True, stdout=None):
                                 "on (n:{0}) ASSERT n.{1} IS UNIQUE".format(
                     cls.__label__, db_property))
             except ClientError as e:
-                if str(e.message).lower().startswith("an equivalent constraint already exists"):
+                if e.code in ('Neo.ClientError.Schema.ConstraintAlreadyExists',
+                              'Neo.ClientError.Schema.EquivalentSchemaRuleAlreadyExists'):
                     stdout.write('{0}\n'.format(str(e)))
                 else:
                     raise


### PR DESCRIPTION
Adding a second exception being ignored to ensure compatibility after neo4j 4.4 update, as well as future updates which might reproduce the same change.

Reason and explanation for this PR are in issue #595 