### PR TITLE
Search frames for class in RelationDefinition

### DIFF
--- a/neomodel/relationship_manager.py
+++ b/neomodel/relationship_manager.py
@@ -1,3 +1,4 @@
+import inspect
 import sys
 import functools
 from importlib import import_module
@@ -356,9 +357,15 @@ class RelationshipManager(object):
 
 class RelationshipDefinition(object):
     def __init__(self, relation_type, cls_name, direction, manager=RelationshipManager, model=None):
-        self.module_name = sys._getframe(4).f_globals['__name__']
-        if '__file__' in sys._getframe(4).f_globals:
-            self.module_file = sys._getframe(4).f_globals['__file__']
+        frames = inspect.getouterframes(inspect.currentframe())
+        frame_number = 4
+        for i, frame in enumerate(frames):
+            if cls_name in frame.frame.f_globals:
+                frame_number = i
+                break
+        self.module_name = sys._getframe(frame_number).f_globals['__name__']
+        if '__file__' in sys._getframe(frame_number).f_globals:
+            self.module_file = sys._getframe(frame_number).f_globals['__file__']
         self._raw_class = cls_name
         self.manager = manager
         self.definition = {}


### PR DESCRIPTION
If [django_neomodel](/neo4j-contrib/django-neomodel) is used and the model definition is dynamically generated with the `type()` builtin like described in #318, the stack frame number used in the `RelationshipDefinition` might be wrong (off by one - but might be even more off in other situations) and the class definition will not be found. This results in an exception like `module 'importlib._bootstrap' has no attribute 'NodeClass'` where `NodeClass` is the node class used in the relationship.

Currently, the `RelationshipDefinition` uses a hard coded frame number to retrieve the node class used for a relationship. Depending on the stack layout, this might be the wrong frame. Therefore this PR suggests to use Python's inspect module to search all outer frames for the node class and use the number of the the frame with the first match.