### PR TITLE
Update deflate for DateProperty

### DIFF
--- a/neomodel/properties.py
+++ b/neomodel/properties.py
@@ -457,7 +457,7 @@ class DateProperty(Property):
         if not isinstance(value, date):
             msg = 'datetime.date object expected, got {0}'.format(repr(value))
             raise ValueError(msg)
-        return value.isoformat()
+        return value
 
 class DateTimeFormatProperty(Property):
     """


### PR DESCRIPTION
When trying to filter a node set on a date property the filter doesn't work and I traced it back to the deflate method of DateProperty that returns an iso format of the date which makes it an ordinary string in the matching query instead of a date object
either change that or add a special handling for date properties in process_filter_args in match.py