### PR TITLE
Update match.py

### DIFF
--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -1,10 +1,9 @@
 from .core import StructuredNode, db
-from .properties import AliasProperty, DateProperty
+from .properties import AliasProperty
 from .exceptions import MultipleNodesReturned
 from .match_q import Q, QBase
 import inspect
 import re
-from datetime import date
 OUTGOING, INCOMING, EITHER = 1, -1, 0
 
 
@@ -202,11 +201,6 @@ def process_filter_args(cls, kwargs):
         if isinstance(property_obj, AliasProperty):
             prop = property_obj.aliased_to()
             deflated_value = getattr(cls, prop).deflate(value)
-        elif isinstance(property_obj, DateProperty):
-            if not isinstance(value, date):
-                msg = 'datetime.date object expected, got {0}'.format(repr(value))
-                raise ValueError(msg)
-            deflated_value = value
         else:
             # handle special operators
             if operator == _SPECIAL_OPERATOR_IN:

--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -1,9 +1,10 @@
 from .core import StructuredNode, db
-from .properties import AliasProperty
+from .properties import AliasProperty, DateProperty
 from .exceptions import MultipleNodesReturned
 from .match_q import Q, QBase
 import inspect
 import re
+from datetime import date
 OUTGOING, INCOMING, EITHER = 1, -1, 0
 
 
@@ -201,6 +202,11 @@ def process_filter_args(cls, kwargs):
         if isinstance(property_obj, AliasProperty):
             prop = property_obj.aliased_to()
             deflated_value = getattr(cls, prop).deflate(value)
+        elif isinstance(property_obj, DateProperty):
+            if not isinstance(value, date):
+                msg = 'datetime.date object expected, got {0}'.format(repr(value))
+                raise ValueError(msg)
+            deflated_value = value
         else:
             # handle special operators
             if operator == _SPECIAL_OPERATOR_IN:

--- a/neomodel/properties.py
+++ b/neomodel/properties.py
@@ -457,7 +457,7 @@ class DateProperty(Property):
         if not isinstance(value, date):
             msg = 'datetime.date object expected, got {0}'.format(repr(value))
             raise ValueError(msg)
-        return value.isoformat()
+        return value
 
 class DateTimeFormatProperty(Property):
     """


### PR DESCRIPTION
Filtering a node set on a date property doesn't work, I traced it back to the process_filter_args function in match.py where the DateProperty deflate method returns iso format which results in the matching query parameter value being a string instead of a datetime.date object therefore it doesn't match it, I handled it with a condition on the DateProperty but it can be handled by changing the deflate method's return as well