### PR TITLE
WIP: Add multi-hop support to RelationshipDefinition

### DIFF
--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -14,7 +14,7 @@ except NameError:
     basestring = str
 
 
-def _rel_helper(lhs, rhs, ident=None, relation_type=None, direction=None, relation_properties=None, **kwargs):
+def _rel_helper(lhs, rhs, ident=None, relation_type=None, direction=None, relation_properties=None, n_hops=None, **kwargs):
     """
     Generate a relationship matching string, with specified parameters.
     Examples:
@@ -56,7 +56,12 @@ def _rel_helper(lhs, rhs, ident=None, relation_type=None, direction=None, relati
         stmt = stmt.format('[*]')
     else:
         # explicit relation_type
-        stmt = stmt.format('[{0}:`{1}`{2}]'.format(ident if ident else '', relation_type, rel_props))
+        stmt = stmt.format('[{0}:`{1}`{2}{3}]'.format(
+            ident if ident else '',
+            relation_type,
+            n_hops if n_hops else '',
+            rel_props,
+        ))
 
     return "({0}){1}({2})".format(lhs, stmt, rhs)
 

--- a/neomodel/relationship_manager.py
+++ b/neomodel/relationship_manager.py
@@ -362,7 +362,7 @@ class RelationshipManager(object):
 
 
 class RelationshipDefinition(object):
-    def __init__(self, relation_type, cls_name, direction, manager=RelationshipManager, model=None):
+    def __init__(self, relation_type, cls_name, direction, manager=RelationshipManager, model=None, n_hops=None):
         frames = inspect.getouterframes(inspect.currentframe())
         frame_number = 4
         for i, frame in enumerate(frames):
@@ -374,10 +374,12 @@ class RelationshipDefinition(object):
             self.module_file = sys._getframe(frame_number).f_globals['__file__']
         self._raw_class = cls_name
         self.manager = manager
-        self.definition = {}
-        self.definition['relation_type'] = relation_type
-        self.definition['direction'] = direction
-        self.definition['model'] = model
+        self.definition = {
+            'relation_type': relation_type,
+            'direction': direction,
+            'model': model,
+            'n_hops': n_hops
+        }
 
         if model is not None:
             # Relationships are easier to instantiate because (at the moment), they cannot have multiple labels. So, a


### PR DESCRIPTION
I want to add support for multiple-hop relationship definitions. For example:

```
Class Person(StructuredNode):
  name = StringProperty()
  
  parent = RelationshipTo('Person', 'PARENT')
  ancenstors = RelationshipTo('Person', 'PARENT', n_hops='*')
  decendants = RelationshipFrom('Person', 'PARENT', n_hops='*')
```

I am open for ideas and pointers!