### PR TITLE
Add RelationshipManager.reversed() as a shortcut to reversed relationships

### DIFF
--- a/neomodel/cardinality.py
+++ b/neomodel/cardinality.py
@@ -44,7 +44,7 @@ class ZeroOrOne(RelationshipManager):
 
 
 class OneOrMore(RelationshipManager):
-    """ A relationship to zero or more nodes. """
+    """ A relationship to one or more nodes. """
     description = "one or more relationships"
 
     def single(self):


### PR DESCRIPTION
This PR wants to introduce `.reversed()` as a shortcut to get a new relationship manager for edges in the reversed direction of the original manager. For example:

```python
class Animal(StructuredNode):
  ate = RelationshipTo('Animal', 'ATE')

a = Animal().save()
b = Animal().save()

a.ate.connect(b)

# get "eaten" relation
b.ate.reversed().all()
```

While this example is quite contrived, I found myself wanting to traverse some relationships backwards without having to declare them twice. This method seems like a nice way of achieving this.