### PR TITLE
Fixes #277 relationship match return node set

### DIFF
--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -783,14 +783,14 @@ class Traversal(BaseSet):
         self.name = name
         self.filters = []
 
-    def match(self, **kwargs):
+    def match(self, **kwargs) -> NodeSet:
         """
         Traverse relationships with properties matching the given parameters.
 
             e.g: `.match(price__lt=10)`
 
         :param kwargs: see `NodeSet.filter()` for syntax
-        :return: self
+        :return: NodeSet
         """
         if kwargs:
             if self.definition.get('model') is None:
@@ -798,4 +798,4 @@ class Traversal(BaseSet):
             output = process_filter_args(self.definition['model'], kwargs)
             if output:
                 self.filters.append(output)
-        return self
+        return NodeSet(self)

--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -574,6 +574,9 @@ class NodeSet(BaseSet):
             self.source_class = source
         elif isinstance(source, StructuredNode):
             self.source_class = source.__class__
+        elif isinstance(source, NodeSet):
+            self.source_class = source.source_class
+            self.source = source.source
         else:
             raise ValueError("Bad source for nodeset " + repr(source))
 

--- a/neomodel/relationship_manager.py
+++ b/neomodel/relationship_manager.py
@@ -325,12 +325,12 @@ class RelationshipManager(object):
         except IndexError:
             pass
 
-    def match(self, **kwargs):
+    def match(self, **kwargs) -> NodeSet:
         """
-        Return set of nodes who's relationship properties match supplied args
+        Return set of nodes whose relationship properties match supplied args
 
         :param kwargs: same syntax as `NodeSet.filter()`
-        :return: NodeSet
+        :return: NodeSet of the resulting traversal
         """
         return self._new_traversal().match(**kwargs)
 

--- a/test/test_issue277.py
+++ b/test/test_issue277.py
@@ -1,0 +1,18 @@
+from neomodel import StructuredNode, StructuredRel, StringProperty, UniqueIdProperty, RelationshipTo, NodeSet
+
+
+class SomeRel(StructuredRel):
+    prop = StringProperty()
+
+
+class SomeNode(StructuredNode):
+    identifier = UniqueIdProperty()
+
+    connected_to = RelationshipTo('SomeNode', 'CONNECTED', model=SomeRel)
+
+
+def test_rel_match_returns_node_set():
+    a = SomeNode()
+    a.save()
+
+    assert type(a.connected_to.match(prop="asdf")) is NodeSet


### PR DESCRIPTION
This is an attempt at fixing #277. I am not sure if such a breaking change would be justified though. Looking at the code, I definitely get the feeling, that it's *supposed* to return a NodeSet.

This probably has to wait for the next minor or even major release for that reason...