### PR TITLE
Minor corrections to get the documentation rebuilt with zero errors.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ If you need assistance with neomodel, please create an issue on the GitHub repo 
     :target: https://neomodel.readthedocs.io/en/latest/?badge=latest
 
 Maintenance notice
-=============
+==================
 
 This project didn't receive releases between December 2021 and early 2023. Active maintenance of the project is now being picked up again.
 Please look at the Issues page, and especially this thread for more information about the current plan : https://github.com/neo4j-contrib/neomodel/issues/653
@@ -61,7 +61,7 @@ Contributing
 
 Ideas, bugs, tests and pull requests always welcome. Please use GitHub's Issues page to track these.
 
-If you are interested in developing `neomodel` further, pick a subject from the Issues page and open a Pull Request (PR) for 
+If you are interested in developing ``neomodel`` further, pick a subject from the Issues page and open a Pull Request (PR) for 
 it. If you are adding a feature that is not captured in that list yet, consider if the work for it could also 
 contribute towards delivering any of the existing issues too.
 
@@ -72,18 +72,19 @@ Make sure you have a Neo4j database version 4 or higher to run the tests on.::
 
     $ export NEO4J_BOLT_URL=bolt://<username>:<password>@localhost:7687 # check your username and password
 
-Ensure `dbms.security.auth_enabled=true` in your database configuration file.
-Setup a virtual environment, install neomodel for development and run the test suite::
+Ensure ``dbms.security.auth_enabled=true`` in your database configuration file.
+Setup a virtual environment, install neomodel for development and run the test suite: ::
 
     $ pip install -e '.[dev]'
     $ pytest
 
 If you are running a neo4j database for the first time the test suite will set the password to 'test'.
 If the database is already populated, the test suite will abort with an error message and ask you to re-run it with the
-`--resetdb` switch. This is a safeguard to ensure that the test suite does not accidentally wipe out a database if you happen to not have restarted your Neo4j server to point to a (usually named) `debug.db` database.
+``--resetdb`` switch. This is a safeguard to ensure that the test suite does not accidentally wipe out a database if you happen 
+to not have restarted your Neo4j server to point to a (usually named) ``debug.db`` database.
 
 If you have ``docker-compose`` installed, you can run the test suite against all supported Python
-interpreters and neo4j versions::
+interpreters and neo4j versions: ::
 
     # in the project's root folder:
     $ sh ./tests-with-docker-compose.sh

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -2,10 +2,10 @@
 import os
 import sys
 
-from neomodel import __version__, __author__, __package__
-
 sys.path.insert(0, os.path.abspath('_themes'))
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath('../../'))
+
+from neomodel import __version__, __author__, __package__
 
 import alabaster
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -19,7 +19,7 @@ An Object Graph Mapper (OGM) for the Neo4j_ graph database, built on the awesome
 Requirements
 ============
 
-- Python 3.4+
+- Python 3.7+
 - neo4j 3.5, 4.x+
 
 Installation

--- a/neomodel/__init__.py
+++ b/neomodel/__init__.py
@@ -22,12 +22,5 @@ __author__ = 'Robin Edwards'
 __email__ = 'robin.ge@gmail.com'
 __license__ = 'MIT'
 __package__ = 'neomodel'
-if (sys.version_info.major, sys.version_info.minor) >= (3, 8):
-    from importlib.metadata import version
-    neo_version = version('neomodel')
-else:
-    import pkg_resources
-    neo_version = pkg_resources.get_distribution('neomodel').version
-
-__version__ = neo_version
+__version__ = '4.0.9'
 


### PR DESCRIPTION
As per the title of the PR, please note manual module metadata (`__version`) setting for the moment at least.