### PR TITLE
Modified pyproject.toml to properly install the neomodel scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "neobolt==1.7.17",
     "six==1.16.0",
 ]
-dynamic = ["version"]
+version='4.0.10'
 
 [project.urls]
 documentation = "https://neomodel.readthedocs.io/en/latest/"
@@ -56,5 +56,5 @@ dev = [
 addopts = "--resetdb"
 
 [project.scripts]
-install-labels = "scripts.neomodel_install_labels:main"
-remove-labels = "scripts.neomodel_remove_labels:main"
+neomodel_install_labels = "scripts.neomodel_install_labels:main"
+neomodel_remove_labels = "scripts.neomodel_remove_labels:main"


### PR DESCRIPTION
This PR solves two problems with `pyproject.toml` on `4.0.10`:

1. The version is brought back to "static" (to resolve problems with installing a local (dev) version); and more importantly
2. The `neomodel` scripts getting their proper names
    * In `4.0.10` they are installed as `install-labels`