### PR TITLE
Addressing #592 and #421

### DIFF
--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -770,7 +770,7 @@ class Traversal(BaseSet):
                             "{0}".format(type(source)))
 
         invalid_keys = (
-                set(definition) - {'direction', 'model', 'node_class', 'relation_type'}
+                set(definition) - {'direction', 'model', 'node_class', 'relation_type', 'from', 'to'}
         )
         if invalid_keys:
             raise ValueError(

--- a/neomodel/relationship_manager.py
+++ b/neomodel/relationship_manager.py
@@ -383,15 +383,17 @@ class RelationshipDefinition(object):
         self._raw_class = cls_name
         self.manager = manager
         self.definition = {}
-        self.definition['relation_type'] = relation_type
         self.definition['direction'] = direction
         self.definition['model'] = model
+        self.definition['from'] = current_frame.f_back.f_back.f_back.f_code.co_name
+        self.definition['to'] = cls_name if type(cls_name) is str else cls_name.__name__
+        self.definition['relation_type'] = f"{relation_type}_{self.definition['from']}_{self.definition['to']}"
 
         if model is not None:
             # Relationships are easier to instantiate because (at the moment), they cannot have multiple labels. So, a
             # relationship's type determines the class that should be instantiated uniquely. Here however, we still use
             # a `frozenset([relation_type])` to preserve the mapping type.
-            label_set = frozenset([relation_type])
+            label_set = frozenset([self.definition['relation_type']])
             try:
                 # If the relationship mapping exists then it is attempted to be redefined so that it applies to the same
                 # label. In this case, it has to be ensured that the class that is overriding the relationship is a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "neobolt==1.7.17",
     "six==1.16.0",
 ]
-dynamic = ["version"]
+version='4.0.10'
 
 [project.urls]
 documentation = "https://neomodel.readthedocs.io/en/latest/"
@@ -56,5 +56,5 @@ dev = [
 addopts = "--resetdb"
 
 [project.scripts]
-install-labels = "scripts.neomodel_install_labels:main"
-remove-labels = "scripts.neomodel_remove_labels:main"
+neomodel_install_labels = "scripts.neomodel_install_labels:main"
+neomodel_remove_labels = "scripts.neomodel_remove_labels:main"


### PR DESCRIPTION
#421 Enabled structured relationships with inheritance by extending the idea of node model inheritance. However, because relationships do not support multiple labels, the connection between neomodel relationship model and CYPHER relationship was 1:1.

Unfortunately, this created the following condition which is "allowed" from the point of view of data modelling but currently neomodel falls over:

```
class AlphaBetaRel(neomodel.StructuredRel):
    comment = neomodel.StringProperty()

class GammaDeltaRel(neomodel.StructuredRel):
    a = neomodel.IntegerProperty()

class Alpha(neomodel.StructuredNode):
    an_id = neomodel.UniqueIdProperty()
    prop_a = neomodel.StringProperty(required = True)
    also_known_as = neomodel.RelationshipTo("Beta", "ALSO_KNOWN_AS", model=AlphaBetaRel)

class Beta(neomodel.StructuredNode):
    an_id = neomodel.UniqueIdProperty()
    prop_b = neomodel.StringProperty(required = True)

class Gamma(neomodel.StructuredNode):
    an_id = neomodel.UniqueIdProperty()
    prop_c = neomodel.IntegerProperty(required = True)
    also_known_as = neomodel.RelationshipTo("Delta", "ALSO_KNOWN_AS", model=GammaDeltaRel)

class Delta(neomodel.StructuredNode):
    an_id = neomodel.UniqueIdProperty()
    prop_d = neomodel.IntegerProperty(required = True)
```

In this case, `ALSO_KNOWN_AS` is a relationship between two unrelated entities that just happen to have a similar requirement for a relationship.

But, currently, neomodel would parse the first relationship without a problem and then take the definition of the second relationship as a re-definition of the first (when they should be independent).

The proposed "fix", appends the source and destination class names to the relationship, therefore making it unique. (Another idea would be to append the model to the relationship).

Similarly to this, it could be possible to "decorate" a given relationship with "multiple labels" (e.g. `SOME_REL|L1|L2|L3`) making it queryable too (by applying filters on the single relationship label) and of course extensible (by inheritance).

The downside(s) of this are that in the absence of the OGM, the relationships would not be comprehensible and the relationship "labels" could end up really big as strings.

I am leaving this here for further consideration in case it helps enable other features.