### PR TITLE
Make slicing returns a NodeSet.

### DIFF
--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -553,7 +553,7 @@ class BaseSet(object):
             elif key.start:
                 self.skip = key.start
 
-            return self.query_cls(self).build_ast()._execute()
+            return self
 
         elif isinstance(key, int):
             self.skip = key


### PR DESCRIPTION
According to documentation:
https://neomodel.readthedocs.io/en/latest/queries.html?highlight=count#iteration-slicing-and-more

Slicing a NodeSet is supposed to return a NodeSet so it allows us to continue chaining calls.

The current implementation is actually returning a list. This fix is an attempt to make code consistent with documentation.