### PR TITLE
Remove deprecated methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ lib
 pyvenv.cfg
 coverage_report/
 .coverage*
+.DS_STORE
+cov.xml

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,6 @@
+Version 5.0.1 2023-xx
+* Removed deprecated methods StructuredRel.delete and RelationshipManager.search
+
 Version 5.0.0 2023-03
 * Confirmed support of Neo4j versions 5.x and 4.4 (LTS)
 * Dropped support of EOL Neo4j versions (4.3 and below)

--- a/neomodel/core.py
+++ b/neomodel/core.py
@@ -316,18 +316,6 @@ class StructuredNode(NodeBase):
 
         return NodeSet(cls)
 
-    @property
-    def _id(self, val):
-        warnings.warn(
-            "the _id property is deprecated please use .id",
-            category=DeprecationWarning,
-            stacklevel=1,
-        )
-        if val:
-            self.id = val
-
-        return self.id
-
     # methods
 
     @classmethod

--- a/neomodel/relationship.py
+++ b/neomodel/relationship.py
@@ -48,12 +48,6 @@ class StructuredRel(StructuredRelBase):
 
         return self
 
-    @deprecated("This method will be removed in neomodel 4")
-    def delete(self):
-        raise NotImplementedError(
-            "Can not delete relationships please use 'disconnect'"
-        )
-
     def start_node(self):
         """
         Get start node

--- a/neomodel/relationship.py
+++ b/neomodel/relationship.py
@@ -1,7 +1,6 @@
 from .core import db
 from .hooks import hooks
 from .properties import Property, PropertyManager
-from .util import deprecated
 
 
 class RelationshipMeta(type):

--- a/neomodel/relationship_manager.py
+++ b/neomodel/relationship_manager.py
@@ -15,7 +15,7 @@ from .match import (
     _rel_merge_helper,
 )
 from .relationship import StructuredRel
-from .util import _get_node_properties, deprecated, enumerate_traceback
+from .util import _get_node_properties, enumerate_traceback
 
 # basestring python 3.x fallback
 try:

--- a/neomodel/relationship_manager.py
+++ b/neomodel/relationship_manager.py
@@ -306,16 +306,6 @@ class RelationshipManager(object):
         """
         return NodeSet(self._new_traversal()).get_or_none(**kwargs)
 
-    @deprecated("search() is now deprecated please use filter() and exclude()")
-    def search(self, **kwargs):
-        """
-        Retrieve related nodes matching the provided properties.
-
-        :param kwargs: same syntax as `NodeSet.filter()`
-        :return: NodeSet
-        """
-        return self.filter(**kwargs).all()
-
     def filter(self, *args, **kwargs):
         """
         Retrieve related nodes matching the provided properties.


### PR DESCRIPTION
Deprecated methods since version 3 with deprecation notice :

- StructuredRel.delete() - _Replaced by .disconnect()_
- RelationshipManager.search() - _Replaced by .filter() and .exclude()_