### PR TITLE
Add support for relationship uniqueness constraints

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,6 @@
 Version 5.1.2 2023-09
 * Raise ValueError on reserved keywords ; add tests #590 #623
+* Add support for relationship property uniqueness constraints. Introduced in Neo4j 5.7.
 * Bumped neo4j-driver to 5.12.0
 
 Version 5.1.1 2023-08

--- a/doc/source/relationships.rst
+++ b/doc/source/relationships.rst
@@ -50,6 +50,9 @@ Neomodel uses :mod:`~neomodel.relationship` models to define the properties stor
             index=True
         )
         met = StringProperty()
+        # Uniqueness constraints for relationship properties
+        # are only available from Neo4j version 5.7 onwards
+        meeting_id = StringProperty(unique_index=True)
 
     class Person(StructuredNode):
         name = StringProperty()

--- a/neomodel/core.py
+++ b/neomodel/core.py
@@ -5,7 +5,11 @@ from itertools import combinations
 from neo4j.exceptions import ClientError
 
 from neomodel import config
-from neomodel.exceptions import DoesNotExist, NodeClassAlreadyDefined
+from neomodel.exceptions import (
+    DoesNotExist,
+    FeatureNotSupported,
+    NodeClassAlreadyDefined,
+)
 from neomodel.hooks import hooks
 from neomodel.properties import Property, PropertyManager
 from neomodel.util import Database, _get_node_properties, _UnsavedNode, classproperty
@@ -160,6 +164,22 @@ def _create_relationship_index(relationship_type: str, property_name: str, stdou
             raise
 
 
+def _create_relationship_constraint(relationship_type: str, property_name: str, stdout):
+    try:
+        db.cypher_query(
+            f"""CREATE CONSTRAINT constraint_unique_{relationship_type}_{property_name} 
+                        FOR ()-[r:{relationship_type}]-() REQUIRE r.{property_name} IS UNIQUE"""
+        )
+    except ClientError as e:
+        if e.code in (
+            RULE_ALREADY_EXISTS,
+            CONSTRAINT_ALREADY_EXISTS,
+        ):
+            stdout.write(f"{str(e)}\n")
+        else:
+            raise
+
+
 def _install_node(cls, name, property, quiet, stdout):
     # Create indexes and constraints for node property
     db_property = property.db_property or name
@@ -201,6 +221,21 @@ def _install_relationship(cls, relationship, quiet, stdout):
                     property_name=db_property,
                     stdout=stdout,
                 )
+            elif property.unique_index:
+                if db.version_is_higher_than("5.7"):
+                    if not quiet:
+                        stdout.write(
+                            f" + Creating relationship unique constraint for {prop_name} on relationship type {relationship_type} for relationship model {cls.__module__}.{relationship_cls.__name__}\n"
+                        )
+                    _create_relationship_constraint(
+                        relationship_type=relationship_type,
+                        property_name=db_property,
+                        stdout=stdout,
+                    )
+                else:
+                    raise FeatureNotSupported(
+                        f"Unique indexes on relationships are not supported in Neo4j version {db.database_version}. Please upgrade to Neo4j 5.7 or higher."
+                    )
 
 
 def install_all_labels(stdout=None):

--- a/neomodel/util.py
+++ b/neomodel/util.py
@@ -479,6 +479,27 @@ class Database(local):
 
         return constraints_as_dict
 
+    def version_is_higher_than(self, version_tag: str) -> bool:
+        """Returns true if the database version is higher or equal to a given tag
+
+        Args:
+            version_tag (str): The version to compare against
+
+        Returns:
+            bool: True if the database version is higher or equal to the given version
+        """
+        return version_tag_to_integer(self.database_version) >= version_tag_to_integer(
+            version_tag
+        )
+
+    def edition_is_enterprise(self) -> bool:
+        """Returns true if the database edition is enterprise
+
+        Returns:
+            bool: True if the database edition is enterprise
+        """
+        return self.database_edition == "enterprise"
+
 
 class TransactionProxy:
     bookmarks: Optional[Bookmarks] = None
@@ -602,3 +623,21 @@ def enumerate_traceback(initial_frame):
         yield depth, frame
         frame = frame.f_back
         depth += 1
+
+
+def version_tag_to_integer(version_tag):
+    """
+    Converts a version string to an integer representation to allow for quick comparisons between versions.
+
+    :param a_version_string: The version string to be converted (e.g. '3.4.0')
+    :type a_version_string: str
+    :return: An integer representation of the version string (e.g. '3.4.0' --> 340)
+    :rtype: int
+    """
+    components = version_tag.split(".")
+    while len(components) < 3:
+        components.append("0")
+    num = 0
+    for a_component in enumerate(components):
+        num += (10 ** ((len(components) - 1) - a_component[0])) * int(a_component[1])
+    return num

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,10 +4,9 @@ import os
 import warnings
 
 import pytest
-from neo4j.exceptions import ClientError as CypherError
-from neobolt.exceptions import ClientError
 
-from neomodel import change_neo4j_password, clear_neo4j_database, config, db
+from neomodel import clear_neo4j_database, config, db
+from neomodel.util import version_tag_to_integer
 
 
 def pytest_addoption(parser):
@@ -82,23 +81,6 @@ def pytest_sessionstart(session):
         db.cypher_query("GRANT IMPERSONATE (troygreene) ON DBMS TO admin")
 
 
-def version_to_dec(a_version_string):
-    """
-    Converts a version string to a number to allow for quick checks on the versions of specific components.
-
-    :param a_version_string: The version string under test (e.g. '3.4.0')
-    :type a_version_string: str
-    :return: An integer representation of the string version, e.g. '3.4.0' --> 340
-    """
-    components = a_version_string.split(".")
-    while len(components) < 3:
-        components.append("0")
-    num = 0
-    for a_component in enumerate(components):
-        num += (10 ** ((len(components) - 1) - a_component[0])) * int(a_component[1])
-    return num
-
-
 def check_and_skip_neo4j_least_version(required_least_neo4j_version, message):
     """
     Checks if the NEO4J_VERSION is at least `required_least_neo4j_version` and skips a test if not.
@@ -112,12 +94,15 @@ def check_and_skip_neo4j_least_version(required_least_neo4j_version, message):
     :type message: str
     :return: A boolean value of True if the version reported is at least `required_least_neo4j_version`
     """
-    if "NEO4J_VERSION" in os.environ:
-        if version_to_dec(os.environ["NEO4J_VERSION"]) < required_least_neo4j_version:
-            pytest.skip(
-                "Neo4j version: {}. {}."
-                "Skipping test.".format(os.environ["NEO4J_VERSION"], message)
-            )
+    if (
+        "NEO4J_VERSION" in os.environ
+        and version_tag_to_integer(os.environ["NEO4J_VERSION"])
+        < required_least_neo4j_version
+    ):
+        pytest.skip(
+            "Neo4j version: {}. {}."
+            "Skipping test.".format(os.environ["NEO4J_VERSION"], message)
+        )
 
 
 @pytest.fixture

--- a/test/test_contrib/test_spatial_datatypes.py
+++ b/test/test_contrib/test_spatial_datatypes.py
@@ -13,23 +13,7 @@ import shapely
 
 import neomodel
 import neomodel.contrib.spatial_properties
-
-
-def version_to_dec(a_version_string):
-    """
-    Converts a version string to a number to allow for quick checks on the versions of specific components.
-
-    :param a_version_string: The version string under test (e.g. '3.4.0')
-    :type a_version_string: str
-    :return: An integer representation of the string version, e.g. '3.4.0' --> 340
-    """
-    components = a_version_string.split(".")
-    while len(components) < 3:
-        components.append("0")
-    num = 0
-    for a_component in enumerate(components):
-        num += (10 ** ((len(components) - 1) - a_component[0])) * int(a_component[1])
-    return num
+from neomodel.util import version_tag_to_integer
 
 
 def check_and_skip_neo4j_least_version(required_least_neo4j_version, message):
@@ -46,7 +30,10 @@ def check_and_skip_neo4j_least_version(required_least_neo4j_version, message):
     :return: A boolean value of True if the version reported is at least `required_least_neo4j_version`
     """
     if "NEO4J_VERSION" in os.environ:
-        if version_to_dec(os.environ["NEO4J_VERSION"]) < required_least_neo4j_version:
+        if (
+            version_tag_to_integer(os.environ["NEO4J_VERSION"])
+            < required_least_neo4j_version
+        ):
             pytest.skip(
                 "Neo4j version: {}. {}."
                 "Skipping test.".format(os.environ["NEO4J_VERSION"], message)

--- a/test/test_dbms_awareness.py
+++ b/test/test_dbms_awareness.py
@@ -1,0 +1,22 @@
+from pytest import mark
+
+from neomodel import db
+
+
+@mark.skipif(
+    db.database_version != "5.7.0", reason="Testing a specific database version"
+)
+def test_version_awareness():
+    assert db.database_version == "5.7.0"
+    assert db.version_is_higher_than("5.7")
+    assert db.version_is_higher_than("5")
+    assert db.version_is_higher_than("4")
+
+    assert not db.version_is_higher_than("5.8")
+
+
+def test_edition_awareness():
+    if db.database_edition == "enterprise":
+        assert db.edition_is_enterprise()
+    else:
+        assert not db.edition_is_enterprise()

--- a/test/test_driver_options.py
+++ b/test/test_driver_options.py
@@ -7,7 +7,7 @@ from neomodel.exceptions import FeatureNotSupported
 
 
 @pytest.mark.skipif(
-    db.database_edition != "enterprise", reason="Skipping test for community edition"
+    not db.edition_is_enterprise(), reason="Skipping test for community edition"
 )
 def test_impersonate():
     with db.impersonate(user="troygreene"):
@@ -16,7 +16,7 @@ def test_impersonate():
 
 
 @pytest.mark.skipif(
-    db.database_edition != "enterprise", reason="Skipping test for community edition"
+    not db.edition_is_enterprise(), reason="Skipping test for community edition"
 )
 def test_impersonate_unauthorized():
     with db.impersonate(user="unknownuser"):
@@ -25,7 +25,7 @@ def test_impersonate_unauthorized():
 
 
 @pytest.mark.skipif(
-    db.database_edition != "enterprise", reason="Skipping test for community edition"
+    not db.edition_is_enterprise(), reason="Skipping test for community edition"
 )
 def test_impersonate_multiple_transactions():
     with db.impersonate(user="troygreene"):
@@ -42,7 +42,7 @@ def test_impersonate_multiple_transactions():
 
 
 @pytest.mark.skipif(
-    db.database_edition == "enterprise", reason="Skipping test for enterprise edition"
+    db.edition_is_enterprise(), reason="Skipping test for enterprise edition"
 )
 def test_impersonate_community():
     with raises(FeatureNotSupported):

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -30,7 +30,7 @@ def test_unique_error():
 
 
 @pytest.mark.skipif(
-    db.database_edition != "enterprise", reason="Skipping test for community edition"
+    not db.edition_is_enterprise(), reason="Skipping test for community edition"
 )
 def test_existence_constraint_error():
     db.cypher_query(

--- a/test/test_label_install.py
+++ b/test/test_label_install.py
@@ -122,10 +122,19 @@ def test_relationship_unique_index_not_supported():
     class UniqueIndexRelationship(StructuredRel):
         name = StringProperty(unique_index=True)
 
+    class TargetNodeForUniqueIndexRelationship(StructuredNode):
+        pass
+
     with pytest.raises(
         FeatureNotSupported, match=r".*Please upgrade to Neo4j 5.7 or higher"
     ):
-        install_labels(UniqueIndexRelationship)
+
+        class NodeWithUniqueIndexRelationship(StructuredNode):
+            has_rel = RelationshipTo(
+                TargetNodeForUniqueIndexRelationship,
+                "UNIQUE_INDEX_REL",
+                model=UniqueIndexRelationship,
+            )
 
 
 @pytest.mark.skipif(not db.version_is_higher_than("5.7"), reason="Supported from 5.7")

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -7,7 +7,6 @@ from pytest import raises
 from neomodel import (
     DateProperty,
     IntegerProperty,
-    Relationship,
     StringProperty,
     StructuredNode,
     StructuredRel,


### PR DESCRIPTION
Feature introduced in Neo4j 5.7. Throws a FeatureNotSupported exception if used while connected to a <5.7 Neo4j database.

Also add some tests for database version and edition detection.