### PR TITLE
Fix #589 match relationship with same name as source and target nodes

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,6 +1,7 @@
 Version 5.1.2 2023-09
 * Raise ValueError on reserved keywords ; add tests #590 #623
 * Add support for relationship property uniqueness constraints. Introduced in Neo4j 5.7.
+* Fix various issues, including fetching self-referencing relationship with same name as node labels #589
 * Bumped neo4j-driver to 5.12.0
 
 Version 5.1.1 2023-08

--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -422,12 +422,13 @@ class QueryBuilder:
         rhs_label = ":" + traversal.target_class.__label__
 
         # build source
+        rel_ident = self.create_ident()
         lhs_ident = self.build_source(traversal.source)
-        rhs_ident = traversal.name + rhs_label
-        self._ast.return_clause = traversal.name
+        traversal_ident = f"{traversal.name}_{rel_ident}"
+        rhs_ident = traversal_ident + rhs_label
+        self._ast.return_clause = traversal_ident
         self._ast.result_class = traversal.target_class
 
-        rel_ident = self.create_ident()
         stmt = _rel_helper(
             lhs=lhs_ident,
             rhs=rhs_ident,
@@ -439,7 +440,7 @@ class QueryBuilder:
         if traversal.filters:
             self.build_where_stmt(rel_ident, traversal.filters)
 
-        return traversal.name
+        return traversal_ident
 
     def _additional_return(self, name):
         if name not in self._ast.additional_return and name != self._ast.return_clause:

--- a/test/test_match_api.py
+++ b/test/test_match_api.py
@@ -41,6 +41,10 @@ class Coffee(StructuredNode):
     id_ = IntegerProperty()
 
 
+class Extension(StructuredNode):
+    extension = RelationshipTo("Extension", "extension")
+
+
 def test_filter_exclude_via_labels():
     Coffee(name="Java", price=99).save()
 
@@ -111,7 +115,7 @@ def test_simple_traverse_with_filter():
 
     assert qb._ast.lookup
     assert qb._ast.match
-    assert qb._ast.return_clause == "suppliers"
+    assert qb._ast.return_clause.startswith("suppliers")
     assert len(results) == 1
     assert results[0].name == "Sainsburys"
 
@@ -178,6 +182,13 @@ def test_issue_208():
 
     assert len(b.suppliers.match(courier="fedex"))
     assert len(b.suppliers.match(courier="dhl"))
+
+
+def test_issue_589():
+    node1 = Extension().save()
+    node2 = Extension().save()
+    node1.extension.connect(node2)
+    assert node2 in node1.extension.all()
 
 
 def test_contains():


### PR DESCRIPTION
See #589 

To prevent this, when building a traversal, name the target node as "{traversal_name}_{relationship_name}".

So the new query will look like :

`MATCH (extension) WHERE id(extension)=12796 WITH extension MATCH ((extension)-[r1:extension]->(extension_r1:Extension)) RETURN extension_r1`

