### PR TITLE
Bug fix in `element_id`.

### DIFF
--- a/neomodel/cardinality.py
+++ b/neomodel/cardinality.py
@@ -128,7 +128,7 @@ class One(RelationshipManager):
         :param properties: relationship properties
         :return: True / rel instance
         """
-        if not hasattr(self.source, "element_id"):
+        if not hasattr(self.source, "element_id") or self.source.element_id is None:
             raise ValueError("Node has not been saved cannot connect!")
         if len(self):
             raise AttemptedCardinalityViolation("Node already has one relationship")

--- a/neomodel/core.py
+++ b/neomodel/core.py
@@ -413,7 +413,7 @@ class StructuredNode(NodeBase):
             int(self.element_id_property)
             if db.database_version.startswith("4")
             else self.element_id_property
-        )
+        ) if hasattr(self, "element_id_property") else None 
 
     # Version 4.4 support - id is deprecated in version 5.x
     @property
@@ -758,7 +758,7 @@ class StructuredNode(NodeBase):
         """
 
         # create or update instance node
-        if hasattr(self, "element_id"):
+        if hasattr(self, "element_id_property"):
             # update
             params = self.deflate(self.__properties__, self)
             query = f"MATCH (n) WHERE {db.get_id_method()}(n)=$self\n"

--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -733,7 +733,7 @@ class BaseSet:
 
     def __contains__(self, obj):
         if isinstance(obj, StructuredNode):
-            if hasattr(obj, "element_id"):
+            if hasattr(obj, "element_id") and obj.element_id is not None:
                 return self.query_cls(self).build_ast()._contains(obj.element_id)
             raise ValueError("Unsaved node: " + repr(obj))
 

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -98,10 +98,18 @@ def test_first_and_first_or_none():
     assert n is None
 
 
+def test_bare_init_without_save():
+    """
+    If a node model is initialised without being saved, accessing its `element_id` should
+    return None.
+    """
+    assert(User().element_id is None)
+
+
 def test_save_to_model():
     u = User(email="jim@test.com", age=3)
     assert u.save()
-    assert u.element_id != ""
+    assert u.element_id is not None
     assert u.email == "jim@test.com"
     assert u.age == 3
 
@@ -109,7 +117,7 @@ def test_save_to_model():
 def test_save_node_without_properties():
     n = NodeWithoutProperty()
     assert n.save()
-    assert n.element_id != ""
+    assert n.element_id is not None
 
 
 def test_unique():


### PR DESCRIPTION
 If a node object is initialised but not yet saved to the database, then its `element_id` should return a suitable value to denote that the object is unsaved. Before switching to `element_id`, we used to examine the `_id` of an element to be able to tell if the node was saved or not. 

The intention [seems to be there](https://github.com/neo4j-contrib/neomodel/blob/master/test/test_models.py#L104) but since `element_id_property` is a dynamical property, [it was not getting a default value](https://github.com/neo4j-contrib/neomodel/blob/master/neomodel/core.py#L412). (Unsaved nodes do not have their `element_id` property at all and therefore `.element_id` was failing. On the same subject, [this line](https://github.com/neo4j-contrib/neomodel/blob/master/neomodel/core.py#L761) had to be modified as well, otherwise the node would not save (better to check the attribute that the property maps rather than the property itself anyway).

Regarding a possible default value for `element_id_property`,  I am not sure that [this](https://github.com/aanastasiou/neomodel/blob/rc/5.1.3/neomodel/core.py#L416) is better than giving `StructuredNode` an `element_id_attribute` with a default value, but it seemed to be the way to go to maintain compatibility. I would suggest that we go with a default property on a subsequent major release.

Following this, the tests were also adapted to ensure that we check that an uninitialised object can be handled properly and that it gives us a chance to interrogate its `element_id` to understand if it is saved or not.

P.S. Certain tests still fail locally :/ but they do not seem related to this particular edit. Nevertheless, I am just noting here that, although this was a small fix, not all tests completed successfully and because of their nature, I am not sure if they could be related or not  (the Aura ones are definitely not related, this is for sure, but a couple of tests on "concurrency" were also failing).