### PR TITLE
chore: remove runtime dependency on `pkg_resources`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Ensure `dbms.security.auth_enabled=true` in your database configuration
 file. Setup a virtual environment, install neomodel for development and
 run the test suite: :
 
-    $ pip install -e '.[dev]'
+    $ pip install -e '.[dev,pandas,numpy]'
     $ pytest
 
 The tests in \"test_connection.py\" will fail locally if you don\'t

--- a/neomodel/__init__.py
+++ b/neomodel/__init__.py
@@ -1,5 +1,4 @@
 # pep8: noqa
-import pkg_resources
 
 from neomodel.exceptions import *
 from neomodel.match import EITHER, INCOMING, OUTGOING, NodeSet, Traversal


### PR DESCRIPTION
The `pkg_resources` import is unused and it requires users to have `setuptools` installed.