### PR TITLE
Incorrect query for count of objects #769

### DIFF
--- a/test/test_match_api.py
+++ b/test/test_match_api.py
@@ -140,6 +140,13 @@ def test_count():
     count = QueryBuilder(NodeSet(source=Coffee)).build_ast()._count()
     assert count > 0
 
+    Coffee(name="Kawa", price=27).save()
+    node_set = NodeSet(source=Coffee)
+    node_set.skip = 1
+    node_set.limit = 1
+    count = QueryBuilder(node_set).build_ast()._count()
+    assert count == 1
+
 
 def test_len_and_iter_and_bool():
     iterations = 0


### PR DESCRIPTION
Issue was when count was used in combination with skip/limit.

Had to change the query builder so that pagination happens to variables before the count aggregation is applied.