### PR TITLE
Respect db_property attribute in relationships and semi-structured nodes

### DIFF
--- a/neomodel/contrib/semi_structured.py
+++ b/neomodel/contrib/semi_structured.py
@@ -1,6 +1,6 @@
-from neomodel import get_graph_entity_properties
 from neomodel.core import StructuredNode
 from neomodel.exceptions import DeflateConflict, InflateConflict
+from neomodel.util import get_graph_entity_properties
 
 
 class SemiStructuredNode(StructuredNode):
@@ -25,40 +25,44 @@ class SemiStructuredNode(StructuredNode):
 
     @classmethod
     def inflate(cls, node):
-        # support lazy loading
-        if isinstance(node, str) or isinstance(node, int):
-            snode = cls()
-            snode.element_id_property = node
-        else:
-            props = {}
-            node_properties = {}
-            for key, prop in cls.__all_properties__:
-                node_properties = get_graph_entity_properties(node)
-                if key in node_properties:
-                    props[key] = prop.inflate(node_properties[key], node)
-                elif prop.has_default:
-                    props[key] = prop.default_value()
-                else:
-                    props[key] = None
-            # handle properties not defined on the class
-            for free_key in (x for x in node_properties if x not in props):
-                if hasattr(cls, free_key):
-                    raise InflateConflict(
-                        cls, free_key, node_properties[free_key], node.element_id
-                    )
-                props[free_key] = node_properties[free_key]
+        # Inflate all properties registered in the class definition
+        snode = super().inflate(node)
 
-            snode = cls(**props)
-            snode.element_id_property = node.element_id
+        # Node can be a string or int for lazy loading (See StructuredNode.inflate). In that case, `node` has nothing
+        # that can be unpacked further.
+        if not hasattr(node, "items"):
+            return snode
+
+        # Inflate all extra properties not registered in the class definition
+        registered_db_property_names = {
+            property.get_db_property_name(name)
+            for name, property in cls.defined_properties(
+                aliases=False, rels=False
+            ).items()
+        }
+        extra_keys = node.keys() - registered_db_property_names
+        for extra_key in extra_keys:
+            value = node[extra_key]
+            if hasattr(cls, extra_key):
+                raise InflateConflict(cls, extra_key, value, snode.element_id)
+            setattr(snode, extra_key, value)
 
         return snode
 
     @classmethod
     def deflate(cls, node_props, obj=None, skip_empty=False):
+        # Deflate all properties registered in the class definition
         deflated = super().deflate(node_props, obj, skip_empty=skip_empty)
-        for key in [k for k in node_props if k not in deflated]:
-            if hasattr(cls, key) and (getattr(cls, key).required or not skip_empty):
-                raise DeflateConflict(cls, key, deflated[key], obj.element_id)
 
-        node_props.update(deflated)
-        return node_props
+        # Deflate all extra properties not registered in the class definition
+        registered_names = cls.defined_properties(aliases=False, rels=False).keys()
+        extra_keys = node_props.keys() - registered_names
+        for extra_key in extra_keys:
+            value = node_props[extra_key]
+            if hasattr(cls, extra_key):
+                raise DeflateConflict(
+                    cls, extra_key, value, node_props.get("element_id")
+                )
+            deflated[extra_key] = node_props[extra_key]
+
+        return deflated

--- a/neomodel/contrib/semi_structured.py
+++ b/neomodel/contrib/semi_structured.py
@@ -1,6 +1,6 @@
+from neomodel import get_graph_entity_properties
 from neomodel.core import StructuredNode
 from neomodel.exceptions import DeflateConflict, InflateConflict
-from neomodel.util import _get_node_properties
 
 
 class SemiStructuredNode(StructuredNode):
@@ -33,7 +33,7 @@ class SemiStructuredNode(StructuredNode):
             props = {}
             node_properties = {}
             for key, prop in cls.__all_properties__:
-                node_properties = _get_node_properties(node)
+                node_properties = get_graph_entity_properties(node)
                 if key in node_properties:
                     props[key] = prop.inflate(node_properties[key], node)
                 elif prop.has_default:
@@ -57,7 +57,7 @@ class SemiStructuredNode(StructuredNode):
     def deflate(cls, node_props, obj=None, skip_empty=False):
         deflated = super().deflate(node_props, obj, skip_empty=skip_empty)
         for key in [k for k in node_props if k not in deflated]:
-            if hasattr(cls, key) and (getattr(cls,key).required or not skip_empty):
+            if hasattr(cls, key) and (getattr(cls, key).required or not skip_empty):
                 raise DeflateConflict(cls, key, deflated[key], obj.element_id)
 
         node_props.update(deflated)

--- a/neomodel/core.py
+++ b/neomodel/core.py
@@ -12,7 +12,12 @@ from neomodel.exceptions import (
 )
 from neomodel.hooks import hooks
 from neomodel.properties import Property, PropertyManager
-from neomodel.util import Database, _get_node_properties, _UnsavedNode, classproperty
+from neomodel.util import (
+    Database,
+    _UnsavedNode,
+    classproperty,
+    get_graph_entity_properties,
+)
 
 db = Database()
 
@@ -666,20 +671,7 @@ class StructuredNode(NodeBase):
             snode = cls()
             snode.element_id_property = node
         else:
-            node_properties = _get_node_properties(node)
-            props = {}
-            for key, prop in cls.__all_properties__:
-                # map property name from database to object property
-                db_property = prop.db_property or key
-
-                if db_property in node_properties:
-                    props[key] = prop.inflate(node_properties[db_property], node)
-                elif prop.has_default:
-                    props[key] = prop.default_value()
-                else:
-                    props[key] = None
-
-            snode = cls(**props)
+            snode = super().inflate(node)
             snode.element_id_property = node.element_id
 
         return snode

--- a/neomodel/core.py
+++ b/neomodel/core.py
@@ -192,7 +192,7 @@ def _create_relationship_constraint(relationship_type: str, property_name: str, 
 
 def _install_node(cls, name, property, quiet, stdout):
     # Create indexes and constraints for node property
-    db_property = property.db_property or name
+    db_property = property.get_db_property_name(name)
     if property.index:
         if not quiet:
             stdout.write(
@@ -220,7 +220,7 @@ def _install_relationship(cls, relationship, quiet, stdout):
         for prop_name, property in relationship_cls.defined_properties(
             aliases=False, rels=False
         ).items():
-            db_property = property.db_property or prop_name
+            db_property = property.get_db_property_name(prop_name)
             if property.index:
                 if not quiet:
                     stdout.write(
@@ -451,7 +451,7 @@ class StructuredNode(NodeBase):
         n_merge_labels = ":".join(cls.inherited_labels())
         n_merge_prm = ", ".join(
             (
-                f"{getattr(cls, p).db_property or p}: params.create.{getattr(cls, p).db_property or p}"
+                f"{getattr(cls, p).get_db_property_name(p)}: params.create.{getattr(cls, p).get_db_property_name(p)}"
                 for p in cls.__required_properties__
             )
         )

--- a/neomodel/core.py
+++ b/neomodel/core.py
@@ -12,12 +12,7 @@ from neomodel.exceptions import (
 )
 from neomodel.hooks import hooks
 from neomodel.properties import Property, PropertyManager
-from neomodel.util import (
-    Database,
-    _UnsavedNode,
-    classproperty,
-    get_graph_entity_properties,
-)
+from neomodel.util import Database, _UnsavedNode, classproperty
 
 db = Database()
 

--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -247,7 +247,9 @@ def process_filter_args(cls, kwargs):
             )
 
         # map property to correct property name in the database
-        db_property = cls.defined_properties(rels=False)[prop].db_property or prop
+        db_property = cls.defined_properties(rels=False)[prop].get_db_property_name(
+            prop
+        )
 
         output[db_property] = (operator, deflated_value)
 

--- a/neomodel/properties.py
+++ b/neomodel/properties.py
@@ -96,7 +96,7 @@ class PropertyManager:
         """
         deflated = {}
         for name, property in cls.defined_properties(aliases=False, rels=False).items():
-            db_property = property.db_property or name
+            db_property = property.get_db_property_name(name)
             if properties.get(name) is not None:
                 deflated[db_property] = property.deflate(properties[name], obj)
             elif property.has_default:
@@ -119,7 +119,7 @@ class PropertyManager:
         """
         inflated = {}
         for name, property in cls.defined_properties(aliases=False, rels=False).items():
-            db_property = property.db_property or name
+            db_property = property.get_db_property_name(name)
             if db_property in graph_entity:
                 inflated[name] = property.inflate(
                     graph_entity[db_property], graph_entity
@@ -240,6 +240,13 @@ class Property:
                 return self.default()
             return self.default
         raise ValueError("No default value specified")
+
+    def get_db_property_name(self, attribute_name):
+        """
+        Returns the name that should be used for the property in the database. This is db_property if supplied upon
+        construction, otherwise the given attribute_name from the model is used.
+        """
+        return self.db_property or attribute_name
 
     @property
     def is_indexed(self):

--- a/neomodel/properties.py
+++ b/neomodel/properties.py
@@ -85,7 +85,15 @@ class PropertyManager:
 
     @classmethod
     def deflate(cls, properties, obj=None, skip_empty=False):
-        # deflate dict ready to be stored
+        """
+        Deflate the properties of a PropertyManager subclass (a user-defined StructuredNode or StructuredRel) so that it
+        can be put into a neo4j.graph.Entity (a neo4j.graph.Node or neo4j.graph.Relationship) for storage. properties
+        can be constructed manually, or fetched from a PropertyManager subclass using __properties__.
+
+        Includes mapping from python class attribute name -> database property name (see Property.db_property).
+
+        Ignores any properties that are not defined as python attributes in the class definition.
+        """
         deflated = {}
         for name, property in cls.defined_properties(aliases=False, rels=False).items():
             db_property = property.db_property or name
@@ -98,6 +106,29 @@ class PropertyManager:
             elif not skip_empty:
                 deflated[db_property] = None
         return deflated
+
+    @classmethod
+    def inflate(cls, graph_entity):
+        """
+        Inflate the properties of a neo4j.graph.Entity (a neo4j.graph.Node or neo4j.graph.Relationship) into an instance
+        of cls.
+
+        Includes mapping from database property name (see Property.db_property) -> python class attribute name.
+
+        Ignores any properties that are not defined as python attributes in the class definition.
+        """
+        inflated = {}
+        for name, property in cls.defined_properties(aliases=False, rels=False).items():
+            db_property = property.db_property or name
+            if db_property in graph_entity:
+                inflated[name] = property.inflate(
+                    graph_entity[db_property], graph_entity
+                )
+            elif property.has_default:
+                inflated[name] = property.default_value()
+            else:
+                inflated[name] = None
+        return cls(**inflated)
 
     @classmethod
     def defined_properties(cls, aliases=True, properties=True, rels=True):

--- a/neomodel/relationship.py
+++ b/neomodel/relationship.py
@@ -158,15 +158,7 @@ class StructuredRel(StructuredRelBase):
         :param rel:
         :return: StructuredRel
         """
-        props = {}
-        for key, prop in cls.defined_properties(aliases=False, rels=False).items():
-            if key in rel:
-                props[key] = prop.inflate(rel[key], obj=rel)
-            elif prop.has_default:
-                props[key] = prop.default_value()
-            else:
-                props[key] = None
-        srel = cls(**props)
+        srel = super().inflate(rel)
         srel._start_node_element_id_property = rel.start_node.element_id
         srel._end_node_element_id_property = rel.end_node.element_id
         srel.element_id_property = rel.element_id

--- a/neomodel/relationship_manager.py
+++ b/neomodel/relationship_manager.py
@@ -15,7 +15,7 @@ from .match import (
     _rel_merge_helper,
 )
 from .relationship import StructuredRel
-from .util import _get_node_properties, enumerate_traceback
+from .util import enumerate_traceback, get_graph_entity_properties
 
 # basestring python 3.x fallback
 try:
@@ -231,7 +231,7 @@ class RelationshipManager(object):
             {"old": old_node.element_id},
         )
         if result:
-            node_properties = _get_node_properties(result[0][0])
+            node_properties = get_graph_entity_properties(result[0][0])
             existing_properties = node_properties.keys()
         else:
             raise NotConnected("reconnect", self.source, old_node)

--- a/neomodel/util.py
+++ b/neomodel/util.py
@@ -662,9 +662,11 @@ class _UnsavedNode:
         return self.__repr__()
 
 
-def _get_node_properties(node):
-    """Get the properties from a neo4j.vx.types.graph.Node object."""
-    return node._properties
+def get_graph_entity_properties(entity):
+    """
+    Get the properties from a neo4j.graph.Entity (neo4j.graph.Node or neo4j.graph.Relationship) object.
+    """
+    return entity._properties
 
 
 def enumerate_traceback(initial_frame):

--- a/test/test_contrib/test_semi_structured.py
+++ b/test/test_contrib/test_semi_structured.py
@@ -1,4 +1,13 @@
-from neomodel import IntegerProperty, StringProperty
+import neo4j.graph
+import pytest
+
+from neomodel import (
+    DeflateConflict,
+    InflateConflict,
+    IntegerProperty,
+    StringProperty,
+    db,
+)
 from neomodel.contrib import SemiStructuredNode
 
 
@@ -28,3 +37,40 @@ def test_save_to_model_with_extras():
 def test_save_empty_model():
     dummy = Dummy()
     assert dummy.save()
+
+
+def test_inflate_conflict():
+    class PersonForInflateTest(SemiStructuredNode):
+        name = StringProperty()
+        age = IntegerProperty()
+
+        def hello(self):
+            print("Hi my names " + self.name)
+
+    # An ok model
+    props = {"name": "Jim", "age": 8, "weight": 11}
+    db.cypher_query("CREATE (n:PersonForInflateTest $props)", {"props": props})
+    jim = PersonForInflateTest.nodes.get(name="Jim")
+    assert jim.name == "Jim"
+    assert jim.age == 8
+    assert jim.weight == 11
+
+    # A model that conflicts on `hello`
+    props = {"name": "Tim", "age": 8, "hello": "goodbye"}
+    db.cypher_query("CREATE (n:PersonForInflateTest $props)", {"props": props})
+    with pytest.raises(InflateConflict):
+        PersonForInflateTest.nodes.get(name="Tim")
+
+
+def test_deflate_conflict():
+    class PersonForDeflateTest(SemiStructuredNode):
+        name = StringProperty()
+        age = IntegerProperty()
+
+        def hello(self):
+            print("Hi my names " + self.name)
+
+    tim = PersonForDeflateTest(name="Tim", age=8, weight=11).save()
+    tim.hello = "Hi"
+    with pytest.raises(DeflateConflict):
+        tim.save()


### PR DESCRIPTION
Fixes https://github.com/neo4j-contrib/neomodel/issues/774 by centralizing `inflate` functionality in order to respect `db_property` attribute in both `StructuredRelationship` and `SemiStructuredNode`.

Added necessary tests for both `StructuredRelationship` and `SemiStructuredNode`, as well as tests for `InflateConflict` and `DeflateConflict`.