### PR TITLE
Add wraps to wrapper defined in TransactionProxy

### DIFF
--- a/neomodel/util.py
+++ b/neomodel/util.py
@@ -3,6 +3,7 @@ import os
 import sys
 import time
 import warnings
+from functools import wraps
 from threading import local
 from typing import Optional, Sequence
 from urllib.parse import quote, unquote, urlparse
@@ -578,6 +579,7 @@ class TransactionProxy:
             self.last_bookmark = self.db.commit()
 
     def __call__(self, func):
+        @wraps(func)
         def wrapper(*args, **kwargs):
             with self:
                 return func(*args, **kwargs)


### PR DESCRIPTION
Hi all,

first for all, thanks for your work and for keeping up to date this library!

I'm using `neomodel` in a FastAPI project to update a neo4j database. For each endpoint reading or writing to the database, I open a new DB transaction using the decorators `write_transaction` and `read_transaction`. 

Since I'm using multiple wrappers from different libraries for each endpoint, I noticed that the `TransactionProxy` `__init__` and `__call__` functions were called when creating the endpoint, but the `wrapper` defined in `__call__` and the `__enter__` and `__exit__` functions were not invoked.

This pull request adds the `functools` `wraps` function to that `wrapper`. Doing this I resolved the problem described before. 

I executed the tests with pytest and they passed. I also noticed that the behavior with easier use cases does not change.

Let me know if this change introduces breaking changes or strange behavior (hopefully not).

Regards