### PR TITLE
feat(match): allow filtering by IN the ArrayProperty

### DIFF
--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -255,33 +255,95 @@ def process_filter_args(cls, kwargs):
     return output
 
 
-def transform_operator_to_filter(operator, filter_key, filter_value, property_obj):
-    # handle special operators
-    if operator == _SPECIAL_OPERATOR_IN:
-        if not isinstance(filter_value, tuple) and not isinstance(filter_value, list):
-            raise ValueError(
-                f"Value must be a tuple or list for IN operation {filter_key}={filter_value}"
-            )
-        if isinstance(property_obj, ArrayProperty):
-            deflated_value = property_obj.deflate(filter_value)
-            operator = _SPECIAL_OPERATOR_ARRAY_IN
-        else:
-            deflated_value = [property_obj.deflate(v) for v in filter_value]
-    elif operator == _SPECIAL_OPERATOR_ISNULL:
-        if not isinstance(filter_value, bool):
-            raise ValueError(
-                f"Value must be a bool for isnull operation on {filter_key}"
-            )
-        operator = "IS NULL" if filter_value else "IS NOT NULL"
-        deflated_value = None
-    elif operator in _REGEX_OPERATOR_TABLE.values():
+def transform_in_operator_to_filter(operator, filter_key, filter_value, property_obj):
+    """
+    Transform in operator to a cypher filter
+
+    Args:
+        operator (str): operator to transform
+        filter_key (str): filter key
+        filter_value (str): filter value
+        property_obj (object): property object
+
+    Returns:
+        tuple: operator, deflated_value
+    """
+    if not isinstance(filter_value, tuple) and not isinstance(filter_value, list):
+        raise ValueError(
+            f"Value must be a tuple or list for IN operation {filter_key}={filter_value}"
+        )
+    if isinstance(property_obj, ArrayProperty):
         deflated_value = property_obj.deflate(filter_value)
-        if not isinstance(deflated_value, str):
-            raise ValueError(f"Must be a string value for {filter_key}")
-        if operator in _STRING_REGEX_OPERATOR_TABLE.values():
-            deflated_value = re.escape(deflated_value)
-        deflated_value = operator.format(deflated_value)
-        operator = _SPECIAL_OPERATOR_REGEX
+        operator = _SPECIAL_OPERATOR_ARRAY_IN
+    else:
+        deflated_value = [property_obj.deflate(v) for v in filter_value]
+
+    return operator, deflated_value
+
+
+def transform_null_operator_to_filter(filter_key, filter_value):
+    """
+    Transform null operator to a cypher filter
+
+    Args:
+        filter_key (str): filter key
+        filter_value (str): filter value
+
+    Returns:
+        tuple: operator, deflated_value
+    """
+    if not isinstance(filter_value, bool):
+        raise ValueError(f"Value must be a bool for isnull operation on {filter_key}")
+    operator = "IS NULL" if filter_value else "IS NOT NULL"
+    deflated_value = None
+    return operator, deflated_value
+
+
+def transform_regex_operator_to_filter(
+    operator, filter_key, filter_value, property_obj
+):
+    """
+    Transform regex operator to a cypher filter
+
+    Args:
+        operator (str): operator to transform
+        filter_key (str): filter key
+        filter_value (str): filter value
+        property_obj (object): property object
+
+    Returns:
+        tuple: operator, deflated_value
+    """
+
+    deflated_value = property_obj.deflate(filter_value)
+    if not isinstance(deflated_value, str):
+        raise ValueError(f"Must be a string value for {filter_key}")
+    if operator in _STRING_REGEX_OPERATOR_TABLE.values():
+        deflated_value = re.escape(deflated_value)
+    deflated_value = operator.format(deflated_value)
+    operator = _SPECIAL_OPERATOR_REGEX
+    return operator, deflated_value
+
+
+def transform_operator_to_filter(operator, filter_key, filter_value, property_obj):
+    if operator == _SPECIAL_OPERATOR_IN:
+        operator, deflated_value = transform_in_operator_to_filter(
+            operator=operator,
+            filter_key=filter_key,
+            filter_value=filter_value,
+            property_obj=property_obj,
+        )
+    elif operator == _SPECIAL_OPERATOR_ISNULL:
+        operator, deflated_value = transform_null_operator_to_filter(
+            filter_key=filter_key, filter_value=filter_value
+        )
+    elif operator in _REGEX_OPERATOR_TABLE.values():
+        operator, deflated_value = transform_regex_operator_to_filter(
+            operator=operator,
+            filter_key=filter_key,
+            filter_value=filter_value,
+            property_obj=property_obj,
+        )
     else:
         deflated_value = property_obj.deflate(filter_value)
 

--- a/test/test_match_api.py
+++ b/test/test_match_api.py
@@ -4,6 +4,7 @@ from pytest import raises
 
 from neomodel import (
     INCOMING,
+    ArrayProperty,
     DateTimeProperty,
     IntegerProperty,
     Q,
@@ -31,6 +32,7 @@ class Supplier(StructuredNode):
 class Species(StructuredNode):
     name = StringProperty()
     coffees = RelationshipFrom("Coffee", "COFFEE SPECIES", model=StructuredRel)
+    tags = ArrayProperty(StringProperty(), default=list)
 
 
 class Coffee(StructuredNode):
@@ -502,3 +504,22 @@ def test_fetch_relations():
     assert tesco in Supplier.nodes.fetch_relations("coffees__species").filter(
         name="Sainsburys"
     )
+
+
+def test_in_filter_with_array_property():
+    tags = ["smoother", "sweeter", "chocolate", "sugar"]
+    no_match = ["organic"]
+    arabica = Species(name="Arabica", tags=tags).save()
+
+    assert arabica in Species.nodes.filter(
+        tags__in=tags
+    ), "Species not found by tags given"
+    assert arabica in Species.nodes.filter(
+        Q(tags__in=tags)
+    ), "Species not found with Q by tags given"
+    assert arabica not in Species.nodes.filter(
+        ~Q(tags__in=tags)
+    ), "Species found by tags given in negated query"
+    assert arabica not in Species.nodes.filter(
+        tags__in=no_match
+    ), "Species found by tags with not match tags given"


### PR DESCRIPTION
I improved the IN filter so that it supports correct usage with the ArrayProperty. I didn't want to make any radical changes. If you agree, I could implement what was suggested in some issues like https://github.com/neo4j-contrib/neomodel/issues/284 and https://github.com/neo4j-contrib/neomodel/issues/379 - the possibility of filtering by contains_values and/or exact_values.