### PR TITLE
neomodel_inspect_database multiple rels for label

### DIFF
--- a/neomodel/scripts/neomodel_inspect_database.py
+++ b/neomodel/scripts/neomodel_inspect_database.py
@@ -126,13 +126,13 @@ class RelationshipInspector:
                 MATCH (n:`{start_label}`)-[r]->(m)
                 WITH DISTINCT type(r) as rel_type, head(labels(m)) AS target_label, keys(r) AS properties, head(collect(r)) AS sampleRel
                 ORDER BY size(properties) DESC
-                RETURN rel_type, target_label, apoc.meta.cypher.types(properties(sampleRel)) AS properties LIMIT 1
+                RETURN DISTINCT rel_type, target_label, collect(DISTINCT apoc.meta.cypher.types(properties(sampleRel)))[0] AS properties
             """
         else:
             query = f"""
                 MATCH (n:`{start_label}`)-[r]->(m)
                 WITH DISTINCT type(r) as rel_type, head(labels(m)) AS target_label
-                RETURN rel_type, target_label, {{}} AS properties LIMIT 1
+                RETURN rel_type, target_label, {{}} AS properties
             """
         result, _ = db.cypher_query(query)
         return [(record[0], record[1], record[2]) for record in result]

--- a/test/data/neomodel_inspect_database_output.txt
+++ b/test/data/neomodel_inspect_database_output.txt
@@ -5,6 +5,7 @@ class ScriptsTestNode(StructuredNode):
     personal_id = StringProperty(unique_index=True)
     name = StringProperty(index=True)
     rel = RelationshipTo("ScriptsTestNode", "REL", cardinality=ZeroOrOne, model="RelRel")
+    other_rel = RelationshipTo("ScriptsTestNode", "OTHER_REL", cardinality=ZeroOrOne)
 
 
 class RelRel(StructuredRel):

--- a/test/data/neomodel_inspect_database_output_light.txt
+++ b/test/data/neomodel_inspect_database_output_light.txt
@@ -5,6 +5,7 @@ class ScriptsTestNode(StructuredNode):
     personal_id = StringProperty(unique_index=True)
     name = StringProperty(index=True)
     rel = RelationshipTo("ScriptsTestNode", "REL")
+    other_rel = RelationshipTo("ScriptsTestNode", "OTHER_REL")
 
 
 class EveryPropertyTypeNode(StructuredNode):

--- a/test/data/neomodel_inspect_database_output_pre_5_7.txt
+++ b/test/data/neomodel_inspect_database_output_pre_5_7.txt
@@ -5,6 +5,7 @@ class ScriptsTestNode(StructuredNode):
     personal_id = StringProperty(unique_index=True)
     name = StringProperty(index=True)
     rel = RelationshipTo("ScriptsTestNode", "REL", cardinality=ZeroOrOne, model="RelRel")
+    other_rel = RelationshipTo("ScriptsTestNode", "OTHER_REL", cardinality=ZeroOrOne)
 
 
 class RelRel(StructuredRel):

--- a/test/data/neomodel_inspect_database_output_pre_5_7_light.txt
+++ b/test/data/neomodel_inspect_database_output_pre_5_7_light.txt
@@ -5,6 +5,7 @@ class ScriptsTestNode(StructuredNode):
     personal_id = StringProperty(unique_index=True)
     name = StringProperty(index=True)
     rel = RelationshipTo("ScriptsTestNode", "REL")
+    other_rel = RelationshipTo("ScriptsTestNode", "OTHER_REL")
 
 
 class EveryPropertyTypeNode(StructuredNode):

--- a/test/test_scripts.py
+++ b/test/test_scripts.py
@@ -21,6 +21,7 @@ class ScriptsTestNode(StructuredNode):
     personal_id = StringProperty(unique_index=True)
     name = StringProperty(index=True)
     rel = RelationshipTo("ScriptsTestNode", "REL", model=ScriptsTestRel)
+    other_rel = RelationshipTo("ScriptsTestNode", "OTHER_REL")
 
 
 def test_neomodel_install_labels():
@@ -113,7 +114,9 @@ def test_neomodel_inspect_database(script_flavour):
     # Create a few nodes and a rel, with indexes and constraints
     node1 = ScriptsTestNode(personal_id="1", name="test").save()
     node2 = ScriptsTestNode(personal_id="2", name="test").save()
+    node3 = ScriptsTestNode(personal_id="3", name="test").save()
     node1.rel.connect(node2, {"some_unique_property": "1", "some_index_property": "2"})
+    node1.other_rel.connect(node3)
 
     # Create a node with all the parsable property types
     # Also create a node with no properties


### PR DESCRIPTION
Fixes bug where inspect database script only returns one rel for each label.

Closes #781 