### PR TITLE
Implement #820: Add support for INCLUDES/INCLUDES_ALL/INCLUDES_ANY operators in cypher filters

### DIFF
--- a/neomodel/async_/match.py
+++ b/neomodel/async_/match.py
@@ -154,6 +154,9 @@ _SPECIAL_OPERATOR_INSENSITIVE = "(?i)"
 _SPECIAL_OPERATOR_ISNULL = "IS NULL"
 _SPECIAL_OPERATOR_ISNOTNULL = "IS NOT NULL"
 _SPECIAL_OPERATOR_REGEX = "=~"
+_SPECIAL_OPERATOR_INCLUDES = "{val} IN {ident}.{prop}"
+_SPECIAL_OPERATOR_INCLUDES_ALL = "all(x IN {val} WHERE x IN {ident}.{prop})"
+_SPECIAL_OPERATOR_INCLUDES_ANY = "any(x IN {val} WHERE x IN {ident}.{prop})"
 
 _UNARY_OPERATORS = (_SPECIAL_OPERATOR_ISNULL, _SPECIAL_OPERATOR_ISNOTNULL)
 
@@ -190,6 +193,9 @@ OPERATOR_TABLE = {
     "isnull": _SPECIAL_OPERATOR_ISNULL,
     "regex": _SPECIAL_OPERATOR_REGEX,
     "exact": "=",
+    "includes": _SPECIAL_OPERATOR_INCLUDES,
+    "includes_all": _SPECIAL_OPERATOR_INCLUDES_ALL,
+    "includes_any": _SPECIAL_OPERATOR_INCLUDES_ANY,
 }
 # add all regex operators
 OPERATOR_TABLE.update(_REGEX_OPERATOR_TABLE)
@@ -254,6 +260,62 @@ def process_filter_args(cls, kwargs):
         output[db_property] = (operator, deflated_value)
 
     return output
+
+
+def transform_includes_operator_to_filter(
+    operator, filter_key, filter_value, property_obj
+):
+    """
+    Transform includes operator to a cypher filter
+    Args:
+        operator (str): operator to transform
+        filter_key (str): filter key
+        filter_value (str): filter value
+        property_obj (object): property object
+    Returns:
+        tuple: operator, deflated_value
+    """
+    if not isinstance(filter_value, str):
+        raise ValueError(
+            f"Value must be a string for INCLUDES operation {filter_key}={filter_value}"
+        )
+    if not isinstance(property_obj, ArrayProperty):
+        raise ValueError(
+            f"Property {filter_key} must be an ArrayProperty to use INCLUDES operation"
+        )
+    deflated_value = filter_value
+    operator = _SPECIAL_OPERATOR_INCLUDES
+    return operator, deflated_value
+
+
+def transform_includes_all_any_operator_to_filter(
+    operator, filter_key, filter_value, property_obj
+):
+    """
+    Transform includes operator to a cypher filter
+    Args:
+        operator (str): operator to transform
+        filter_key (str): filter key
+        filter_value (str): filter value
+        property_obj (object): property object
+    Returns:
+        tuple: operator, deflated_value
+    """
+    if not isinstance(filter_value, (tuple, list)):
+        raise ValueError(
+            f"Value must be an iterable for INCLUDES operation {filter_key}={filter_value}"
+        )
+    if not isinstance(property_obj, ArrayProperty):
+        raise ValueError(
+            f"Property {filter_key} must be an ArrayProperty to use INCLUDES operation"
+        )
+    deflated_value = property_obj.deflate(filter_value)
+    operator = (
+        _SPECIAL_OPERATOR_INCLUDES_ANY
+        if operator == _SPECIAL_OPERATOR_INCLUDES_ANY
+        else _SPECIAL_OPERATOR_INCLUDES_ALL
+    )
+    return operator, deflated_value
 
 
 def transform_in_operator_to_filter(operator, filter_key, filter_value, property_obj):
@@ -334,6 +396,20 @@ def transform_operator_to_filter(operator, filter_key, filter_value, property_ob
         )
     elif operator in _REGEX_OPERATOR_TABLE.values():
         operator, deflated_value = transform_regex_operator_to_filter(
+            operator=operator,
+            filter_key=filter_key,
+            filter_value=filter_value,
+            property_obj=property_obj,
+        )
+    elif operator == _SPECIAL_OPERATOR_INCLUDES:
+        operator, deflated_value = transform_includes_operator_to_filter(
+            operator=operator,
+            filter_key=filter_key,
+            filter_value=filter_value,
+            property_obj=property_obj,
+        )
+    elif operator in [_SPECIAL_OPERATOR_INCLUDES_ALL, _SPECIAL_OPERATOR_INCLUDES_ANY]:
+        operator, deflated_value = transform_includes_all_any_operator_to_filter(
             operator=operator,
             filter_key=filter_key,
             filter_value=filter_value,
@@ -640,6 +716,16 @@ class AsyncQueryBuilder:
                                 prop=prop,
                                 val=f"${place_holder}",
                             )
+                        elif operator in [
+                            _SPECIAL_OPERATOR_INCLUDES,
+                            _SPECIAL_OPERATOR_INCLUDES_ALL,
+                            _SPECIAL_OPERATOR_INCLUDES_ANY,
+                        ]:
+                            statement = operator.format(
+                                ident=ident,
+                                prop=prop,
+                                val=f"${place_holder}",
+                            )
                         else:
                             statement = f"{ident}.{prop} {operator} ${place_holder}"
                         self._query_params[place_holder] = val
@@ -673,6 +759,18 @@ class AsyncQueryBuilder:
                         # unary operators do not have a parameter
                         statement = (
                             f"{'NOT' if negate else ''} {ident}.{prop} {operator}"
+                        )
+                    elif operator in [
+                        _SPECIAL_OPERATOR_INCLUDES,
+                        _SPECIAL_OPERATOR_INCLUDES_ALL,
+                        _SPECIAL_OPERATOR_INCLUDES_ANY,
+                    ]:
+                        place_holder = self._register_place_holder(ident + "_" + prop)
+                        self._query_params[place_holder] = val
+                        statement = operator.format(
+                            ident=ident,
+                            prop=prop,
+                            val=f"${place_holder}",
                         )
                     else:
                         place_holder = self._register_place_holder(ident + "_" + prop)

--- a/neomodel/async_/match.py
+++ b/neomodel/async_/match.py
@@ -284,7 +284,6 @@ def transform_includes_operator_to_filter(
             f"Property {filter_key} must be an ArrayProperty to use INCLUDES operation"
         )
     deflated_value = filter_value
-    operator = _SPECIAL_OPERATOR_INCLUDES
     return operator, deflated_value
 
 
@@ -310,12 +309,12 @@ def transform_includes_all_any_operator_to_filter(
             f"Property {filter_key} must be an ArrayProperty to use INCLUDES operation"
         )
     deflated_value = property_obj.deflate(filter_value)
-    operator = (
+    selected_operator = (
         _SPECIAL_OPERATOR_INCLUDES_ANY
         if operator == _SPECIAL_OPERATOR_INCLUDES_ANY
         else _SPECIAL_OPERATOR_INCLUDES_ALL
     )
-    return operator, deflated_value
+    return selected_operator, deflated_value
 
 
 def transform_in_operator_to_filter(operator, filter_key, filter_value, property_obj):

--- a/neomodel/async_/match.py
+++ b/neomodel/async_/match.py
@@ -292,7 +292,7 @@ def transform_includes_all_any_operator_to_filter(
     operator, filter_key, filter_value, property_obj
 ):
     """
-    Transform includes operator to a cypher filter
+    Transform includes__all/any operator to a cypher filter
     Args:
         operator (str): operator to transform
         filter_key (str): filter key
@@ -342,7 +342,7 @@ def transform_in_operator_to_filter(operator, filter_key, filter_value, property
     return operator, deflated_value
 
 
-def transform_null_operator_to_filter(filter_key, filter_value):
+def transform_null_operator_to_filter(filter_key, filter_value, **kwargs):
     """
     Transform null operator to a cypher filter
     Args:
@@ -382,42 +382,29 @@ def transform_regex_operator_to_filter(
     return operator, deflated_value
 
 
-def transform_operator_to_filter(operator, filter_key, filter_value, property_obj):
-    if operator == _SPECIAL_OPERATOR_IN:
-        operator, deflated_value = transform_in_operator_to_filter(
-            operator=operator,
-            filter_key=filter_key,
-            filter_value=filter_value,
-            property_obj=property_obj,
-        )
-    elif operator == _SPECIAL_OPERATOR_ISNULL:
-        operator, deflated_value = transform_null_operator_to_filter(
-            filter_key=filter_key, filter_value=filter_value
-        )
-    elif operator in _REGEX_OPERATOR_TABLE.values():
-        operator, deflated_value = transform_regex_operator_to_filter(
-            operator=operator,
-            filter_key=filter_key,
-            filter_value=filter_value,
-            property_obj=property_obj,
-        )
-    elif operator == _SPECIAL_OPERATOR_INCLUDES:
-        operator, deflated_value = transform_includes_operator_to_filter(
-            operator=operator,
-            filter_key=filter_key,
-            filter_value=filter_value,
-            property_obj=property_obj,
-        )
-    elif operator in [_SPECIAL_OPERATOR_INCLUDES_ALL, _SPECIAL_OPERATOR_INCLUDES_ANY]:
-        operator, deflated_value = transform_includes_all_any_operator_to_filter(
-            operator=operator,
-            filter_key=filter_key,
-            filter_value=filter_value,
-            property_obj=property_obj,
-        )
-    else:
-        deflated_value = property_obj.deflate(filter_value)
+TRANSFORM_TABLE = {
+    (_SPECIAL_OPERATOR_IN,): transform_in_operator_to_filter,
+    (_SPECIAL_OPERATOR_ISNULL,): transform_null_operator_to_filter,
+    tuple(_REGEX_OPERATOR_TABLE.values()): transform_regex_operator_to_filter,
+    (_SPECIAL_OPERATOR_INCLUDES,): transform_includes_operator_to_filter,
+    (
+        _SPECIAL_OPERATOR_INCLUDES_ALL,
+        _SPECIAL_OPERATOR_INCLUDES_ANY,
+    ): transform_includes_all_any_operator_to_filter,
+}
 
+
+def transform_operator_to_filter(operator, filter_key, filter_value, property_obj):
+    for ops_it, transform in TRANSFORM_TABLE.items():
+        if operator in ops_it:
+            return transform(
+                operator=operator,
+                filter_key=filter_key,
+                filter_value=filter_value,
+                property_obj=property_obj,
+            )
+
+    deflated_value = property_obj.deflate(filter_value)
     return operator, deflated_value
 
 
@@ -710,13 +697,8 @@ class AsyncQueryBuilder:
                         statement = f"{ident}.{prop} {operator}"
                     else:
                         place_holder = self._register_place_holder(ident + "_" + prop)
-                        if operator == _SPECIAL_OPERATOR_ARRAY_IN:
-                            statement = operator.format(
-                                ident=ident,
-                                prop=prop,
-                                val=f"${place_holder}",
-                            )
-                        elif operator in [
+                        if operator in [
+                            _SPECIAL_OPERATOR_ARRAY_IN,
                             _SPECIAL_OPERATOR_INCLUDES,
                             _SPECIAL_OPERATOR_INCLUDES_ALL,
                             _SPECIAL_OPERATOR_INCLUDES_ANY,
@@ -762,13 +744,8 @@ class AsyncQueryBuilder:
                         )
                     # Fix IN operator for Traversal Sets
                     # Potential bug: Must be investigated if it is really an issue
-                    # elif operator == _SPECIAL_OPERATOR_ARRAY_IN:
-                    #         statement = operator.format(
-                    #             ident=ident,
-                    #             prop=prop,
-                    #             val=f"${place_holder}",
-                    #         )
                     elif operator in [
+                        _SPECIAL_OPERATOR_ARRAY_IN,
                         _SPECIAL_OPERATOR_INCLUDES,
                         _SPECIAL_OPERATOR_INCLUDES_ALL,
                         _SPECIAL_OPERATOR_INCLUDES_ANY,

--- a/neomodel/async_/match.py
+++ b/neomodel/async_/match.py
@@ -760,6 +760,14 @@ class AsyncQueryBuilder:
                         statement = (
                             f"{'NOT' if negate else ''} {ident}.{prop} {operator}"
                         )
+                    # Fix IN operator for Traversal Sets
+                    # Potential bug: Must be investigated if it is really an issue
+                    # elif operator == _SPECIAL_OPERATOR_ARRAY_IN:
+                    #         statement = operator.format(
+                    #             ident=ident,
+                    #             prop=prop,
+                    #             val=f"${place_holder}",
+                    #         )
                     elif operator in [
                         _SPECIAL_OPERATOR_INCLUDES,
                         _SPECIAL_OPERATOR_INCLUDES_ALL,

--- a/neomodel/async_/match.py
+++ b/neomodel/async_/match.py
@@ -1102,6 +1102,9 @@ class AsyncNodeSet(AsyncBaseSet):
              * 'istartswith': case insensitive string starts with
              * 'endswith': string ends with
              * 'iendswith': case insensitive string ends with
+             * 'includes': array contains value
+             * 'includes_all': array contains all values
+             * 'includes_any': array contains any of the values
 
         :return: self
         """

--- a/neomodel/sync_/match.py
+++ b/neomodel/sync_/match.py
@@ -1098,6 +1098,9 @@ class NodeSet(BaseSet):
              * 'istartswith': case insensitive string starts with
              * 'endswith': string ends with
              * 'iendswith': case insensitive string ends with
+             * 'includes': array contains value
+             * 'includes_all': array contains all values
+             * 'includes_any': array contains any of the values
 
         :return: self
         """

--- a/neomodel/sync_/match.py
+++ b/neomodel/sync_/match.py
@@ -154,6 +154,9 @@ _SPECIAL_OPERATOR_INSENSITIVE = "(?i)"
 _SPECIAL_OPERATOR_ISNULL = "IS NULL"
 _SPECIAL_OPERATOR_ISNOTNULL = "IS NOT NULL"
 _SPECIAL_OPERATOR_REGEX = "=~"
+_SPECIAL_OPERATOR_INCLUDES = "{val} IN {ident}.{prop}"
+_SPECIAL_OPERATOR_INCLUDES_ALL = "all(x IN {val} WHERE x IN {ident}.{prop})"
+_SPECIAL_OPERATOR_INCLUDES_ANY = "any(x IN {val} WHERE x IN {ident}.{prop})"
 
 _UNARY_OPERATORS = (_SPECIAL_OPERATOR_ISNULL, _SPECIAL_OPERATOR_ISNOTNULL)
 
@@ -190,6 +193,9 @@ OPERATOR_TABLE = {
     "isnull": _SPECIAL_OPERATOR_ISNULL,
     "regex": _SPECIAL_OPERATOR_REGEX,
     "exact": "=",
+    "includes": _SPECIAL_OPERATOR_INCLUDES,
+    "includes_all": _SPECIAL_OPERATOR_INCLUDES_ALL,
+    "includes_any": _SPECIAL_OPERATOR_INCLUDES_ANY,
 }
 # add all regex operators
 OPERATOR_TABLE.update(_REGEX_OPERATOR_TABLE)
@@ -254,6 +260,62 @@ def process_filter_args(cls, kwargs):
         output[db_property] = (operator, deflated_value)
 
     return output
+
+
+def transform_includes_operator_to_filter(
+    operator, filter_key, filter_value, property_obj
+):
+    """
+    Transform includes operator to a cypher filter
+    Args:
+        operator (str): operator to transform
+        filter_key (str): filter key
+        filter_value (str): filter value
+        property_obj (object): property object
+    Returns:
+        tuple: operator, deflated_value
+    """
+    if not isinstance(filter_value, str):
+        raise ValueError(
+            f"Value must be a string for INCLUDES operation {filter_key}={filter_value}"
+        )
+    if not isinstance(property_obj, ArrayProperty):
+        raise ValueError(
+            f"Property {filter_key} must be an ArrayProperty to use INCLUDES operation"
+        )
+    deflated_value = filter_value
+    operator = _SPECIAL_OPERATOR_INCLUDES
+    return operator, deflated_value
+
+
+def transform_includes_all_any_operator_to_filter(
+    operator, filter_key, filter_value, property_obj
+):
+    """
+    Transform includes operator to a cypher filter
+    Args:
+        operator (str): operator to transform
+        filter_key (str): filter key
+        filter_value (str): filter value
+        property_obj (object): property object
+    Returns:
+        tuple: operator, deflated_value
+    """
+    if not isinstance(filter_value, (tuple, list)):
+        raise ValueError(
+            f"Value must be an iterable for INCLUDES operation {filter_key}={filter_value}"
+        )
+    if not isinstance(property_obj, ArrayProperty):
+        raise ValueError(
+            f"Property {filter_key} must be an ArrayProperty to use INCLUDES operation"
+        )
+    deflated_value = property_obj.deflate(filter_value)
+    operator = (
+        _SPECIAL_OPERATOR_INCLUDES_ANY
+        if operator == _SPECIAL_OPERATOR_INCLUDES_ANY
+        else _SPECIAL_OPERATOR_INCLUDES_ALL
+    )
+    return operator, deflated_value
 
 
 def transform_in_operator_to_filter(operator, filter_key, filter_value, property_obj):
@@ -334,6 +396,20 @@ def transform_operator_to_filter(operator, filter_key, filter_value, property_ob
         )
     elif operator in _REGEX_OPERATOR_TABLE.values():
         operator, deflated_value = transform_regex_operator_to_filter(
+            operator=operator,
+            filter_key=filter_key,
+            filter_value=filter_value,
+            property_obj=property_obj,
+        )
+    elif operator == _SPECIAL_OPERATOR_INCLUDES:
+        operator, deflated_value = transform_includes_operator_to_filter(
+            operator=operator,
+            filter_key=filter_key,
+            filter_value=filter_value,
+            property_obj=property_obj,
+        )
+    elif operator in [_SPECIAL_OPERATOR_INCLUDES_ALL, _SPECIAL_OPERATOR_INCLUDES_ANY]:
+        operator, deflated_value = transform_includes_all_any_operator_to_filter(
             operator=operator,
             filter_key=filter_key,
             filter_value=filter_value,
@@ -640,6 +716,16 @@ class QueryBuilder:
                                 prop=prop,
                                 val=f"${place_holder}",
                             )
+                        elif operator in [
+                            _SPECIAL_OPERATOR_INCLUDES,
+                            _SPECIAL_OPERATOR_INCLUDES_ALL,
+                            _SPECIAL_OPERATOR_INCLUDES_ANY,
+                        ]:
+                            statement = operator.format(
+                                ident=ident,
+                                prop=prop,
+                                val=f"${place_holder}",
+                            )
                         else:
                             statement = f"{ident}.{prop} {operator} ${place_holder}"
                         self._query_params[place_holder] = val
@@ -673,6 +759,18 @@ class QueryBuilder:
                         # unary operators do not have a parameter
                         statement = (
                             f"{'NOT' if negate else ''} {ident}.{prop} {operator}"
+                        )
+                    elif operator in [
+                        _SPECIAL_OPERATOR_INCLUDES,
+                        _SPECIAL_OPERATOR_INCLUDES_ALL,
+                        _SPECIAL_OPERATOR_INCLUDES_ANY,
+                    ]:
+                        place_holder = self._register_place_holder(ident + "_" + prop)
+                        self._query_params[place_holder] = val
+                        statement = operator.format(
+                            ident=ident,
+                            prop=prop,
+                            val=f"${place_holder}",
                         )
                     else:
                         place_holder = self._register_place_holder(ident + "_" + prop)

--- a/neomodel/sync_/match.py
+++ b/neomodel/sync_/match.py
@@ -284,7 +284,6 @@ def transform_includes_operator_to_filter(
             f"Property {filter_key} must be an ArrayProperty to use INCLUDES operation"
         )
     deflated_value = filter_value
-    operator = _SPECIAL_OPERATOR_INCLUDES
     return operator, deflated_value
 
 
@@ -310,12 +309,12 @@ def transform_includes_all_any_operator_to_filter(
             f"Property {filter_key} must be an ArrayProperty to use INCLUDES operation"
         )
     deflated_value = property_obj.deflate(filter_value)
-    operator = (
+    selected_operator = (
         _SPECIAL_OPERATOR_INCLUDES_ANY
         if operator == _SPECIAL_OPERATOR_INCLUDES_ANY
         else _SPECIAL_OPERATOR_INCLUDES_ALL
     )
-    return operator, deflated_value
+    return selected_operator, deflated_value
 
 
 def transform_in_operator_to_filter(operator, filter_key, filter_value, property_obj):

--- a/neomodel/sync_/match.py
+++ b/neomodel/sync_/match.py
@@ -760,6 +760,14 @@ class QueryBuilder:
                         statement = (
                             f"{'NOT' if negate else ''} {ident}.{prop} {operator}"
                         )
+                    # Fix IN operator for Traversal Sets
+                    # Potential bug: Must be investigated if it is really an issue
+                    # elif operator == _SPECIAL_OPERATOR_ARRAY_IN:
+                    #         statement = operator.format(
+                    #             ident=ident,
+                    #             prop=prop,
+                    #             val=f"${place_holder}",
+                    #         )
                     elif operator in [
                         _SPECIAL_OPERATOR_INCLUDES,
                         _SPECIAL_OPERATOR_INCLUDES_ALL,

--- a/neomodel/sync_/match.py
+++ b/neomodel/sync_/match.py
@@ -154,6 +154,9 @@ _SPECIAL_OPERATOR_INSENSITIVE = "(?i)"
 _SPECIAL_OPERATOR_ISNULL = "IS NULL"
 _SPECIAL_OPERATOR_ISNOTNULL = "IS NOT NULL"
 _SPECIAL_OPERATOR_REGEX = "=~"
+_SPECIAL_OPERATOR_INCLUDES = "{val} IN {ident}.{prop}"
+_SPECIAL_OPERATOR_INCLUDES_ALL = "all(x IN {val} WHERE x IN {ident}.{prop})"
+_SPECIAL_OPERATOR_INCLUDES_ANY = "any(x IN {val} WHERE x IN {ident}.{prop})"
 
 _UNARY_OPERATORS = (_SPECIAL_OPERATOR_ISNULL, _SPECIAL_OPERATOR_ISNOTNULL)
 
@@ -190,6 +193,9 @@ OPERATOR_TABLE = {
     "isnull": _SPECIAL_OPERATOR_ISNULL,
     "regex": _SPECIAL_OPERATOR_REGEX,
     "exact": "=",
+    "includes": _SPECIAL_OPERATOR_INCLUDES,
+    "includes_all": _SPECIAL_OPERATOR_INCLUDES_ALL,
+    "includes_any": _SPECIAL_OPERATOR_INCLUDES_ANY,
 }
 # add all regex operators
 OPERATOR_TABLE.update(_REGEX_OPERATOR_TABLE)
@@ -256,6 +262,61 @@ def process_filter_args(cls, kwargs):
     return output
 
 
+def transform_includes_operator_to_filter(
+    operator, filter_key, filter_value, property_obj
+):
+    """
+    Transform includes operator to a cypher filter
+    Args:
+        operator (str): operator to transform
+        filter_key (str): filter key
+        filter_value (str): filter value
+        property_obj (object): property object
+    Returns:
+        tuple: operator, deflated_value
+    """
+    if not isinstance(filter_value, str):
+        raise ValueError(
+            f"Value must be a string for INCLUDES operation {filter_key}={filter_value}"
+        )
+    if not isinstance(property_obj, ArrayProperty):
+        raise ValueError(
+            f"Property {filter_key} must be an ArrayProperty to use INCLUDES operation"
+        )
+    deflated_value = filter_value
+    return operator, deflated_value
+
+
+def transform_includes_all_any_operator_to_filter(
+    operator, filter_key, filter_value, property_obj
+):
+    """
+    Transform includes__all/any operator to a cypher filter
+    Args:
+        operator (str): operator to transform
+        filter_key (str): filter key
+        filter_value (str): filter value
+        property_obj (object): property object
+    Returns:
+        tuple: operator, deflated_value
+    """
+    if not isinstance(filter_value, (tuple, list)):
+        raise ValueError(
+            f"Value must be an iterable for INCLUDES operation {filter_key}={filter_value}"
+        )
+    if not isinstance(property_obj, ArrayProperty):
+        raise ValueError(
+            f"Property {filter_key} must be an ArrayProperty to use INCLUDES operation"
+        )
+    deflated_value = property_obj.deflate(filter_value)
+    selected_operator = (
+        _SPECIAL_OPERATOR_INCLUDES_ANY
+        if operator == _SPECIAL_OPERATOR_INCLUDES_ANY
+        else _SPECIAL_OPERATOR_INCLUDES_ALL
+    )
+    return selected_operator, deflated_value
+
+
 def transform_in_operator_to_filter(operator, filter_key, filter_value, property_obj):
     """
     Transform in operator to a cypher filter
@@ -280,7 +341,7 @@ def transform_in_operator_to_filter(operator, filter_key, filter_value, property
     return operator, deflated_value
 
 
-def transform_null_operator_to_filter(filter_key, filter_value):
+def transform_null_operator_to_filter(filter_key, filter_value, **kwargs):
     """
     Transform null operator to a cypher filter
     Args:
@@ -320,28 +381,29 @@ def transform_regex_operator_to_filter(
     return operator, deflated_value
 
 
-def transform_operator_to_filter(operator, filter_key, filter_value, property_obj):
-    if operator == _SPECIAL_OPERATOR_IN:
-        operator, deflated_value = transform_in_operator_to_filter(
-            operator=operator,
-            filter_key=filter_key,
-            filter_value=filter_value,
-            property_obj=property_obj,
-        )
-    elif operator == _SPECIAL_OPERATOR_ISNULL:
-        operator, deflated_value = transform_null_operator_to_filter(
-            filter_key=filter_key, filter_value=filter_value
-        )
-    elif operator in _REGEX_OPERATOR_TABLE.values():
-        operator, deflated_value = transform_regex_operator_to_filter(
-            operator=operator,
-            filter_key=filter_key,
-            filter_value=filter_value,
-            property_obj=property_obj,
-        )
-    else:
-        deflated_value = property_obj.deflate(filter_value)
+TRANSFORM_TABLE = {
+    (_SPECIAL_OPERATOR_IN,): transform_in_operator_to_filter,
+    (_SPECIAL_OPERATOR_ISNULL,): transform_null_operator_to_filter,
+    tuple(_REGEX_OPERATOR_TABLE.values()): transform_regex_operator_to_filter,
+    (_SPECIAL_OPERATOR_INCLUDES,): transform_includes_operator_to_filter,
+    (
+        _SPECIAL_OPERATOR_INCLUDES_ALL,
+        _SPECIAL_OPERATOR_INCLUDES_ANY,
+    ): transform_includes_all_any_operator_to_filter,
+}
 
+
+def transform_operator_to_filter(operator, filter_key, filter_value, property_obj):
+    for ops_it, transform in TRANSFORM_TABLE.items():
+        if operator in ops_it:
+            return transform(
+                operator=operator,
+                filter_key=filter_key,
+                filter_value=filter_value,
+                property_obj=property_obj,
+            )
+
+    deflated_value = property_obj.deflate(filter_value)
     return operator, deflated_value
 
 
@@ -634,7 +696,12 @@ class QueryBuilder:
                         statement = f"{ident}.{prop} {operator}"
                     else:
                         place_holder = self._register_place_holder(ident + "_" + prop)
-                        if operator == _SPECIAL_OPERATOR_ARRAY_IN:
+                        if operator in [
+                            _SPECIAL_OPERATOR_ARRAY_IN,
+                            _SPECIAL_OPERATOR_INCLUDES,
+                            _SPECIAL_OPERATOR_INCLUDES_ALL,
+                            _SPECIAL_OPERATOR_INCLUDES_ANY,
+                        ]:
                             statement = operator.format(
                                 ident=ident,
                                 prop=prop,
@@ -673,6 +740,21 @@ class QueryBuilder:
                         # unary operators do not have a parameter
                         statement = (
                             f"{'NOT' if negate else ''} {ident}.{prop} {operator}"
+                        )
+                    # Fix IN operator for Traversal Sets
+                    # Potential bug: Must be investigated if it is really an issue
+                    elif operator in [
+                        _SPECIAL_OPERATOR_ARRAY_IN,
+                        _SPECIAL_OPERATOR_INCLUDES,
+                        _SPECIAL_OPERATOR_INCLUDES_ALL,
+                        _SPECIAL_OPERATOR_INCLUDES_ANY,
+                    ]:
+                        place_holder = self._register_place_holder(ident + "_" + prop)
+                        self._query_params[place_holder] = val
+                        statement = operator.format(
+                            ident=ident,
+                            prop=prop,
+                            val=f"${place_holder}",
                         )
                     else:
                         place_holder = self._register_place_holder(ident + "_" + prop)
@@ -1000,6 +1082,9 @@ class NodeSet(BaseSet):
              * 'istartswith': case insensitive string starts with
              * 'endswith': string ends with
              * 'iendswith': case insensitive string ends with
+             * 'includes': array contains value
+             * 'includes_all': array contains all values
+             * 'includes_any': array contains any of the values
 
         :return: self
         """

--- a/test/async_/test_match_api.py
+++ b/test/async_/test_match_api.py
@@ -10,6 +10,7 @@ from neomodel import (
     AsyncRelationshipTo,
     AsyncStructuredNode,
     AsyncStructuredRel,
+    AsyncZeroOrOne,
     DateTimeProperty,
     IntegerProperty,
     Q,
@@ -77,6 +78,23 @@ class PersonX(AsyncStructuredNode):
 
     # traverse outgoing LIVES_IN relations, inflate to City objects
     city = AsyncRelationshipTo(CityX, "LIVES_IN")
+
+
+class MemberOfRelationship(AsyncStructuredRel):
+    tags = ArrayProperty(StringProperty(), required=True)
+
+
+class Player(AsyncStructuredNode):
+    name = StringProperty(unique_index=True, required=True)
+    tags = ArrayProperty(StringProperty(), required=True)
+    club = AsyncRelationshipTo(
+        "Club", "MEMBER_OF", model=MemberOfRelationship, cardinality=AsyncZeroOrOne
+    )
+
+
+class Club(AsyncStructuredNode):
+    name = StringProperty(unique_index=True, required=True)
+    members = AsyncRelationshipFrom("Player", "MEMBER_OF", model=MemberOfRelationship)
 
 
 @mark_async_test
@@ -665,3 +683,105 @@ async def test_async_iterator():
 
         # assert that generator runs loop above
         assert counter == n
+
+
+@mark_async_test
+async def test_includes_filter_with_nodeset():
+    ronaldo = await Player(
+        name="Ronaldo", tags=["player", "striker", "portugal"]
+    ).save()
+    messi = await Player(name="Messi", tags=["player", "striker", "argentina"]).save()
+
+    # Assert __includes works with Q object
+    assert ronaldo in await Player.nodes.filter(Q(tags__includes="striker"))
+
+    # Assert that includes filter works with nodeset
+    assert ronaldo in await Player.nodes.filter(tags__includes="striker")
+    assert messi in await Player.nodes.filter(tags__includes="striker")
+
+    # Assert that includes filter works with nodeset and excluding values
+    assert ronaldo in await Player.nodes.filter(tags__includes="portugal")
+    assert messi not in await Player.nodes.filter(tags__includes="portugal")
+
+    # Assert __includes_any works with Q object
+    assert ronaldo in await Player.nodes.filter(
+        Q(tags__includes_any=["portugal", "argentina"])
+    )
+
+    # Assert that includes_any filter works with nodeset and multiple values
+    assert ronaldo in await Player.nodes.filter(
+        tags__includes_any=["portugal", "argentina"]
+    )
+    assert messi in await Player.nodes.filter(
+        tags__includes_any=["portugal", "argentina"]
+    )
+    assert ronaldo in await Player.nodes.filter(
+        tags__includes_any=["portugal", "striker"]
+    )
+    assert messi in await Player.nodes.filter(
+        tags__includes_any=["portugal", "striker"]
+    )
+
+    # Assert __includes_all works with Q object
+    assert ronaldo in await Player.nodes.filter(
+        Q(tags__includes_all=["player", "striker"])
+    )
+
+    # Assert that includes filter works with nodeset and all values
+    assert ronaldo in await Player.nodes.filter(
+        tags__includes_all=["player", "striker"]
+    )
+    assert messi in await Player.nodes.filter(tags__includes_all=["player", "striker"])
+    assert ronaldo in await Player.nodes.filter(
+        tags__includes_all=["player", "striker", "portugal"]
+    )
+    assert ronaldo not in await Player.nodes.filter(
+        tags__includes_all=["player", "striker", "argentina"]
+    )
+    assert messi not in await Player.nodes.filter(
+        tags__includes_all=["player", "striker", "portugal"]
+    )
+
+
+@mark_async_test
+async def test_includes_filter_with_traversal():
+    # Create the nodes
+    enrique = await Player(name="Enrique", tags=["spain"]).save()
+    donnarumma = await Player(name="Donnarumma", tags=["italia", "right-foot"]).save()
+    dembele = await Player(name="Dembele", tags=["france", "both-feet"]).save()
+    marquinhos = await Player(name="Marquinhos", tags=["brasil", "right-foot"]).save()
+    kolomuani = await Player(name="Kolo Muani", tags=["congo", "right-foot"]).save()
+
+    psg = await Club(name="PSG").save()
+    # Creates the edges
+    await psg.members.connect(enrique, properties={"tags": ["coach"]})
+    await psg.members.connect(donnarumma, properties={"tags": ["player", "goalkeeper"]})
+    await psg.members.connect(marquinhos, properties={"tags": ["player", "defender"]})
+    await psg.members.connect(dembele, properties={"tags": ["player", "forward"]})
+    await psg.members.connect(kolomuani, properties={"tags": ["player", "forward"]})
+
+    # Assert __includes
+    players = await psg.members.match(tags__includes="player").all()
+    assert donnarumma in players
+    assert dembele in players
+    assert marquinhos in players
+    assert kolomuani in players
+    assert enrique not in players
+    assert donnarumma in await psg.members.match(tags__includes="goalkeeper").all()
+    assert dembele not in await psg.members.match(tags__includes="goalkeeper").all()
+
+    # Assert __includes_any
+    players = await psg.members.match(tags__includes_any=["defender", "forward"]).all()
+    assert donnarumma not in players
+    assert dembele in players
+    assert marquinhos in players
+    assert kolomuani in players
+    assert enrique not in players
+
+    # Assert __includes_all
+    players = await psg.members.match(tags__includes_all=["player", "forward"]).all()
+    assert donnarumma not in players
+    assert marquinhos not in players
+    assert enrique not in players
+    assert dembele in players
+    assert kolomuani in players

--- a/test/sync_/test_match_api.py
+++ b/test/sync_/test_match_api.py
@@ -15,6 +15,7 @@ from neomodel import (
     StructuredNode,
     StructuredRel,
     UniqueIdProperty,
+    ZeroOrOne,
 )
 from neomodel._async_compat.util import Util
 from neomodel.exceptions import MultipleNodesReturned, RelationshipClassNotDefined
@@ -70,6 +71,23 @@ class PersonX(StructuredNode):
 
     # traverse outgoing LIVES_IN relations, inflate to City objects
     city = RelationshipTo(CityX, "LIVES_IN")
+
+
+class MemberOfRelationship(StructuredRel):
+    tags = ArrayProperty(StringProperty(), required=True)
+
+
+class Player(StructuredNode):
+    name = StringProperty(unique_index=True, required=True)
+    tags = ArrayProperty(StringProperty(), required=True)
+    club = RelationshipTo(
+        "Club", "MEMBER_OF", model=MemberOfRelationship, cardinality=ZeroOrOne
+    )
+
+
+class Club(StructuredNode):
+    name = StringProperty(unique_index=True, required=True)
+    members = RelationshipFrom("Player", "MEMBER_OF", model=MemberOfRelationship)
 
 
 @mark_sync_test
@@ -654,3 +672,91 @@ def test_async_iterator():
 
         # assert that generator runs loop above
         assert counter == n
+
+
+@mark_sync_test
+def test_includes_filter_with_nodeset():
+    ronaldo = Player(name="Ronaldo", tags=["player", "striker", "portugal"]).save()
+    messi = Player(name="Messi", tags=["player", "striker", "argentina"]).save()
+
+    # Assert __includes works with Q object
+    assert ronaldo in Player.nodes.filter(Q(tags__includes="striker"))
+
+    # Assert that includes filter works with nodeset
+    assert ronaldo in Player.nodes.filter(tags__includes="striker")
+    assert messi in Player.nodes.filter(tags__includes="striker")
+
+    # Assert that includes filter works with nodeset and excluding values
+    assert ronaldo in Player.nodes.filter(tags__includes="portugal")
+    assert messi not in Player.nodes.filter(tags__includes="portugal")
+
+    # Assert __includes_any works with Q object
+    assert ronaldo in Player.nodes.filter(
+        Q(tags__includes_any=["portugal", "argentina"])
+    )
+
+    # Assert that includes_any filter works with nodeset and multiple values
+    assert ronaldo in Player.nodes.filter(tags__includes_any=["portugal", "argentina"])
+    assert messi in Player.nodes.filter(tags__includes_any=["portugal", "argentina"])
+    assert ronaldo in Player.nodes.filter(tags__includes_any=["portugal", "striker"])
+    assert messi in Player.nodes.filter(tags__includes_any=["portugal", "striker"])
+
+    # Assert __includes_all works with Q object
+    assert ronaldo in Player.nodes.filter(Q(tags__includes_all=["player", "striker"]))
+
+    # Assert that includes filter works with nodeset and all values
+    assert ronaldo in Player.nodes.filter(tags__includes_all=["player", "striker"])
+    assert messi in Player.nodes.filter(tags__includes_all=["player", "striker"])
+    assert ronaldo in Player.nodes.filter(
+        tags__includes_all=["player", "striker", "portugal"]
+    )
+    assert ronaldo not in Player.nodes.filter(
+        tags__includes_all=["player", "striker", "argentina"]
+    )
+    assert messi not in Player.nodes.filter(
+        tags__includes_all=["player", "striker", "portugal"]
+    )
+
+
+@mark_sync_test
+def test_includes_filter_with_traversal():
+    # Create the nodes
+    enrique = Player(name="Enrique", tags=["spain"]).save()
+    donnarumma = Player(name="Donnarumma", tags=["italia", "right-foot"]).save()
+    dembele = Player(name="Dembele", tags=["france", "both-feet"]).save()
+    marquinhos = Player(name="Marquinhos", tags=["brasil", "right-foot"]).save()
+    kolomuani = Player(name="Kolo Muani", tags=["congo", "right-foot"]).save()
+
+    psg = Club(name="PSG").save()
+    # Creates the edges
+    psg.members.connect(enrique, properties={"tags": ["coach"]})
+    psg.members.connect(donnarumma, properties={"tags": ["player", "goalkeeper"]})
+    psg.members.connect(marquinhos, properties={"tags": ["player", "defender"]})
+    psg.members.connect(dembele, properties={"tags": ["player", "forward"]})
+    psg.members.connect(kolomuani, properties={"tags": ["player", "forward"]})
+
+    # Assert __includes
+    players = psg.members.match(tags__includes="player").all()
+    assert donnarumma in players
+    assert dembele in players
+    assert marquinhos in players
+    assert kolomuani in players
+    assert enrique not in players
+    assert donnarumma in psg.members.match(tags__includes="goalkeeper").all()
+    assert dembele not in psg.members.match(tags__includes="goalkeeper").all()
+
+    # Assert __includes_any
+    players = psg.members.match(tags__includes_any=["defender", "forward"]).all()
+    assert donnarumma not in players
+    assert dembele in players
+    assert marquinhos in players
+    assert kolomuani in players
+    assert enrique not in players
+
+    # Assert __includes_all
+    players = psg.members.match(tags__includes_all=["player", "forward"]).all()
+    assert donnarumma not in players
+    assert marquinhos not in players
+    assert enrique not in players
+    assert dembele in players
+    assert kolomuani in players


### PR DESCRIPTION
This pull request adds support for the INCLUDES/INCLUDES_ALL/INCLUDES_ANY operators in cypher filters. It includes changes to the `match.py` file in the `neomodel/sync_` directory. The operators allow for filtering based on array values, such as checking if an array contains a specific value or if it contains all or any of a set of values. This enhancement improves the functionality and flexibility of the cypher filters in the codebase.

These operators are usable both in `NodeSet.filter` & `RelationshipManager.match`. It is compatible with `neomodel.Q` filters for `NodeSet.filter` method.

Issue https://github.com/neo4j-contrib/neomodel/issues/820 describes the feature request.