### PR TITLE
Added transaction timeout support

### DIFF
--- a/neomodel/async_/database.py
+++ b/neomodel/async_/database.py
@@ -17,6 +17,7 @@ from neo4j import (
     AsyncResult,
     AsyncSession,
     AsyncTransaction,
+    Query,
     basic_auth,
 )
 from neo4j.api import Bookmarks
@@ -441,7 +442,10 @@ class AsyncDatabase:
 
     @ensure_connection
     async def begin(
-        self, access_mode: str = ACCESS_MODE_WRITE, **parameters: Any
+        self,
+        access_mode: str = ACCESS_MODE_WRITE,
+        timeout: float | None = None,
+        **parameters: Any,
     ) -> None:
         """
         Begins a new transaction. Raises SystemError if a transaction is already active.
@@ -462,7 +466,10 @@ class AsyncDatabase:
         )
 
         assert self._session is not None, "Session has not been created"
-        self._active_transaction = await self._session.begin_transaction()
+        timeout = get_config().transaction_timeout if timeout is None else timeout
+        self._active_transaction = await self._session.begin_transaction(
+            timeout=timeout
+        )
 
     @ensure_connection
     async def commit(self) -> Bookmarks:
@@ -676,6 +683,9 @@ class AsyncDatabase:
         else:
             # Otherwise create a new session in a with to dispose of it after it has been run
             if self.driver:
+                config = get_config()
+                if config.transaction_timeout is not None:
+                    query = Query(query, timeout=config.transaction_timeout)
                 async with self.driver.session(
                     database=self._database_name,
                     impersonated_user=self.impersonated_user,
@@ -696,7 +706,7 @@ class AsyncDatabase:
     async def _run_cypher_query(
         self,
         session: AsyncSession | AsyncTransaction,
-        query: str,
+        query: str | Query,
         params: dict[str, Any],
         handle_unique: bool,
         retry_on_session_expire: bool,
@@ -918,13 +928,11 @@ class AsyncDatabase:
     async def clear_neo4j_database(
         self, clear_constraints: bool = False, clear_indexes: bool = False
     ) -> None:
-        await self.cypher_query(
-            """
+        await self.cypher_query("""
             MATCH (a)
             CALL { WITH a DETACH DELETE a }
             IN TRANSACTIONS OF 5000 rows
-        """
-        )
+        """)
         if clear_constraints:
             await self.drop_constraints()
         if clear_indexes:
@@ -1170,10 +1178,8 @@ class AsyncDatabase:
                 f" + Creating node unique constraint for {property_name} on label {target_cls.__label__} for class {target_cls.__module__}.{target_cls.__name__}\n"
             )
         try:
-            await self.cypher_query(
-                f"""CREATE CONSTRAINT {constraint_name}
-                            FOR (n:{label}) REQUIRE n.{property_name} IS UNIQUE"""
-            )
+            await self.cypher_query(f"""CREATE CONSTRAINT {constraint_name}
+                            FOR (n:{label}) REQUIRE n.{property_name} IS UNIQUE""")
         except ClientError as e:
             if e.code in (
                 RULE_ALREADY_EXISTS,

--- a/neomodel/async_/transaction.py
+++ b/neomodel/async_/transaction.py
@@ -22,10 +22,12 @@ class AsyncTransactionProxy:
         db: AsyncDatabase,
         access_mode: str | None = None,
         parallel_runtime: bool | None = False,
+        timeout: float | None = None,
     ):
         self.db: AsyncDatabase = db
         self.access_mode: str | None = access_mode
         self.parallel_runtime: bool | None = parallel_runtime
+        self.timeout: float | None = timeout
         self.bookmarks: Bookmarks | None = None
         self.last_bookmarks: Bookmarks | None = None
 
@@ -38,7 +40,11 @@ class AsyncTransactionProxy:
             )
             self.parallel_runtime = False
         self.db._parallel_runtime = self.parallel_runtime
-        await self.db.begin(access_mode=self.access_mode, bookmarks=self.bookmarks)
+        await self.db.begin(
+            access_mode=self.access_mode,
+            bookmarks=self.bookmarks,
+            timeout=self.timeout,
+        )
         self.bookmarks = None
         return self
 

--- a/neomodel/config.py
+++ b/neomodel/config.py
@@ -97,6 +97,13 @@ class NeomodelConfig:
             "description": "Maximum transaction retry time in seconds",
         },
     )
+    transaction_timeout: float | None = field(
+        default=None,
+        metadata={
+            "env_var": "NEOMODEL_TRANSACTION_TIMEOUT",
+            "description": "Default transaction timeout in seconds (None = no timeout)",
+        },
+    )
     resolver: Any | None = field(
         default=None,
         metadata={
@@ -201,6 +208,9 @@ class NeomodelConfig:
         if self.max_transaction_retry_time <= 0:
             raise ValueError("max_transaction_retry_time must be positive")
 
+        if self.transaction_timeout is not None and self.transaction_timeout <= 0:
+            raise ValueError("transaction_timeout must be positive")
+
         # Validate slow_queries threshold
         if self.slow_queries < 0:
             raise ValueError("slow_queries must be non-negative")
@@ -227,7 +237,7 @@ class NeomodelConfig:
                     )
                 elif field_type == int:
                     config_data[field_info.name] = int(value)
-                elif field_type == float:
+                elif field_type == float or field_type == (float | None):
                     config_data[field_info.name] = float(value)
                 else:
                     config_data[field_info.name] = value
@@ -435,6 +445,16 @@ class _ConfigModule:
     @MAX_TRANSACTION_RETRY_TIME.setter
     def MAX_TRANSACTION_RETRY_TIME(self, value: float) -> None:
         _set_attr("max_transaction_retry_time", value)
+
+    @property
+    def TRANSACTION_TIMEOUT(
+        self,
+    ) -> float | None:
+        return _get_attr("transaction_timeout")
+
+    @TRANSACTION_TIMEOUT.setter
+    def TRANSACTION_TIMEOUT(self, value: float | None) -> None:
+        _set_attr("transaction_timeout", value)
 
     @property
     def RESOLVER(

--- a/neomodel/scripts/neomodel_inspect_database.py
+++ b/neomodel/scripts/neomodel_inspect_database.py
@@ -93,7 +93,7 @@ class NodeInspector:
     @staticmethod
     def get_constraints_for_label(label):
         constraints, meta_constraints = db.cypher_query(
-            f"SHOW CONSTRAINTS WHERE entityType='NODE' AND '{label}' IN labelsOrTypes AND type='UNIQUENESS'"
+            f"SHOW CONSTRAINTS WHERE entityType='NODE' AND '{label}' IN labelsOrTypes AND type IN ['UNIQUENESS', 'NODE_PROPERTY_UNIQUENESS']"
         )
         constraints_as_dict = [dict(zip(meta_constraints, row)) for row in constraints]
         constrained_properties = [
@@ -144,7 +144,7 @@ class RelationshipInspector:
     @staticmethod
     def get_constraints_for_type(rel_type):
         constraints, meta_constraints = db.cypher_query(
-            f"SHOW CONSTRAINTS WHERE entityType='RELATIONSHIP' AND '{rel_type}' IN labelsOrTypes AND type='RELATIONSHIP_UNIQUENESS'"
+            f"SHOW CONSTRAINTS WHERE entityType='RELATIONSHIP' AND '{rel_type}' IN labelsOrTypes AND type IN ['RELATIONSHIP_UNIQUENESS', 'RELATIONSHIP_PROPERTY_UNIQUENESS']"
         )
         constraints_as_dict = [dict(zip(meta_constraints, row)) for row in constraints]
         constrained_properties = [

--- a/neomodel/sync_/database.py
+++ b/neomodel/sync_/database.py
@@ -14,6 +14,7 @@ from neo4j import (
     DEFAULT_DATABASE,
     Driver,
     GraphDatabase,
+    Query,
     Result,
     Session,
     Transaction,
@@ -438,7 +439,12 @@ class Database:
         return ImpersonationHandler(self, impersonated_user=user)
 
     @ensure_connection
-    def begin(self, access_mode: str = ACCESS_MODE_WRITE, **parameters: Any) -> None:
+    def begin(
+        self,
+        access_mode: str = ACCESS_MODE_WRITE,
+        timeout: float | None = None,
+        **parameters: Any,
+    ) -> None:
         """
         Begins a new transaction. Raises SystemError if a transaction is already active.
         """
@@ -458,7 +464,8 @@ class Database:
         )
 
         assert self._session is not None, "Session has not been created"
-        self._active_transaction = self._session.begin_transaction()
+        timeout = get_config().transaction_timeout if timeout is None else timeout
+        self._active_transaction = self._session.begin_transaction(timeout=timeout)
 
     @ensure_connection
     def commit(self) -> Bookmarks:
@@ -672,6 +679,9 @@ class Database:
         else:
             # Otherwise create a new session in a with to dispose of it after it has been run
             if self.driver:
+                config = get_config()
+                if config.transaction_timeout is not None:
+                    query = Query(query, timeout=config.transaction_timeout)
                 with self.driver.session(
                     database=self._database_name,
                     impersonated_user=self.impersonated_user,
@@ -692,7 +702,7 @@ class Database:
     def _run_cypher_query(
         self,
         session: Session | Transaction,
-        query: str,
+        query: str | Query,
         params: dict[str, Any],
         handle_unique: bool,
         retry_on_session_expire: bool,
@@ -912,13 +922,11 @@ class Database:
     def clear_neo4j_database(
         self, clear_constraints: bool = False, clear_indexes: bool = False
     ) -> None:
-        self.cypher_query(
-            """
+        self.cypher_query("""
             MATCH (a)
             CALL { WITH a DETACH DELETE a }
             IN TRANSACTIONS OF 5000 rows
-        """
-        )
+        """)
         if clear_constraints:
             self.drop_constraints()
         if clear_indexes:
@@ -1162,10 +1170,8 @@ class Database:
                 f" + Creating node unique constraint for {property_name} on label {target_cls.__label__} for class {target_cls.__module__}.{target_cls.__name__}\n"
             )
         try:
-            self.cypher_query(
-                f"""CREATE CONSTRAINT {constraint_name}
-                            FOR (n:{label}) REQUIRE n.{property_name} IS UNIQUE"""
-            )
+            self.cypher_query(f"""CREATE CONSTRAINT {constraint_name}
+                            FOR (n:{label}) REQUIRE n.{property_name} IS UNIQUE""")
         except ClientError as e:
             if e.code in (
                 RULE_ALREADY_EXISTS,

--- a/neomodel/sync_/transaction.py
+++ b/neomodel/sync_/transaction.py
@@ -22,10 +22,12 @@ class TransactionProxy:
         db: Database,
         access_mode: str | None = None,
         parallel_runtime: bool | None = False,
+        timeout: float | None = None,
     ):
         self.db: Database = db
         self.access_mode: str | None = access_mode
         self.parallel_runtime: bool | None = parallel_runtime
+        self.timeout: float | None = timeout
         self.bookmarks: Bookmarks | None = None
         self.last_bookmarks: Bookmarks | None = None
 
@@ -38,7 +40,11 @@ class TransactionProxy:
             )
             self.parallel_runtime = False
         self.db._parallel_runtime = self.parallel_runtime
-        self.db.begin(access_mode=self.access_mode, bookmarks=self.bookmarks)
+        self.db.begin(
+            access_mode=self.access_mode,
+            bookmarks=self.bookmarks,
+            timeout=self.timeout,
+        )
         self.bookmarks = None
         return self
 

--- a/test/async_/test_cypher.py
+++ b/test/async_/test_cypher.py
@@ -2,12 +2,14 @@ import builtins
 from test._async_compat import mark_async_test
 
 import pytest
+from neo4j.exceptions import ClientError
 from neo4j.exceptions import ClientError as CypherError
 from numpy import ndarray
 from pandas import DataFrame, Series
 
 from neomodel import AsyncStructuredNode, StringProperty, adb
 from neomodel._async_compat.util import AsyncUtil
+from neomodel.config import get_config
 
 
 class User2(AsyncStructuredNode):
@@ -50,13 +52,11 @@ async def test_cypher():
     assert data[0][0] == "jim1@test.com"
     assert "a.email" in meta
 
-    data, meta = await jim.cypher(
-        f"""
+    data, meta = await jim.cypher(f"""
             MATCH (a) WHERE {await adb.get_id_method()}(a)=$self
             MATCH (a)<-[:USER2]-(b)
             RETURN a, b, 3
-        """
-    )
+        """)
     assert "a" in meta and "b" in meta
 
 
@@ -167,3 +167,30 @@ async def test_numpy_integration():
     assert isinstance(array, ndarray)
     assert array.shape == (2, 2)
     assert array[0][0] == "jimlu"
+
+
+@mark_async_test
+async def test_cypher_query_transaction_timeout_via_config_fires():
+    config = get_config()
+    original = config.transaction_timeout
+    try:
+        config.transaction_timeout = 1
+        with pytest.raises(
+            ClientError,
+            match="{neo4j_code: Neo.ClientError.Transaction.TransactionTimedOut",
+        ):
+            await adb.cypher_query("CALL apoc.util.sleep(3000)")
+    finally:
+        config.transaction_timeout = original
+
+
+@mark_async_test
+async def test_cypher_query_transaction_timeout_via_config_succeeds():
+    config = get_config()
+    original = config.transaction_timeout
+    try:
+        config.transaction_timeout = 2
+        results, meta = await adb.cypher_query("CALL apoc.util.sleep(500)")
+        assert results is not None
+    finally:
+        config.transaction_timeout = original

--- a/test/async_/test_transactions.py
+++ b/test/async_/test_transactions.py
@@ -6,6 +6,8 @@ from neo4j.exceptions import ClientError, TransactionError
 from pytest import raises
 
 from neomodel import AsyncStructuredNode, StringProperty, UniqueProperty, adb
+from neomodel.async_.transaction import AsyncTransactionProxy
+from neomodel.config import get_config
 
 
 class APerson(AsyncStructuredNode):
@@ -156,7 +158,10 @@ async def test_bookmark_passed_in_to_context(spy_on_db_begin):
     async with transaction:
         pass
 
-    assert (spy_on_db_begin)[-1] == ((), {"access_mode": None, "bookmarks": None})
+    assert (spy_on_db_begin)[-1] == (
+        (),
+        {"access_mode": None, "bookmarks": None, "timeout": None},
+    )
     last_bookmarks = transaction.last_bookmarks
 
     transaction.bookmarks = last_bookmarks
@@ -164,7 +169,7 @@ async def test_bookmark_passed_in_to_context(spy_on_db_begin):
         pass
     assert spy_on_db_begin[-1] == (
         (),
-        {"access_mode": None, "bookmarks": last_bookmarks},
+        {"access_mode": None, "bookmarks": last_bookmarks, "timeout": None},
     )
 
 
@@ -177,3 +182,54 @@ async def test_query_inside_bookmark_transaction():
         assert len([p.name for p in await APerson.nodes]) == 2
 
     assert isinstance(transaction.last_bookmarks, Bookmarks)
+
+
+@mark_async_test
+async def test_transaction_timeout_default(spy_on_db_begin):
+    async with adb.transaction:
+        pass
+
+    assert spy_on_db_begin[-1] == (
+        (),
+        {"access_mode": None, "bookmarks": None, "timeout": None},
+    )
+
+
+@mark_async_test
+async def test_transaction_timeout_explicit(spy_on_db_begin):
+    await adb.begin(timeout=7.5)
+    await adb.rollback()
+
+    assert spy_on_db_begin[-1] == ((), {"timeout": 7.5})
+
+
+@mark_async_test
+async def test_transaction_timeout_fires():
+    with raises(
+        ClientError,
+        match="{neo4j_code: Neo.ClientError.Transaction.TransactionTimedOut",
+    ):
+        async with AsyncTransactionProxy(adb, timeout=1):
+            await adb.cypher_query("CALL apoc.util.sleep(3000)")
+
+
+@mark_async_test
+async def test_transaction_timeout_via_config_fires(spy_on_db_begin):
+    config = get_config()
+    original = config.transaction_timeout
+    try:
+        config.transaction_timeout = 1.42
+        with raises(
+            ClientError,
+            match="{neo4j_code: Neo.ClientError.Transaction.TransactionTimedOut",
+        ):
+            async with AsyncTransactionProxy(adb):
+                await adb.cypher_query("CALL apoc.util.sleep(3000)")
+    finally:
+        config.transaction_timeout = original
+
+
+@mark_async_test
+async def test_transaction_timeout_succeeds():
+    async with AsyncTransactionProxy(adb, timeout=2):
+        await adb.cypher_query("CALL apoc.util.sleep(500)")

--- a/test/sync_/test_cypher.py
+++ b/test/sync_/test_cypher.py
@@ -2,12 +2,14 @@ import builtins
 from test._async_compat import mark_sync_test
 
 import pytest
+from neo4j.exceptions import ClientError
 from neo4j.exceptions import ClientError as CypherError
 from numpy import ndarray
 from pandas import DataFrame, Series
 
 from neomodel import StringProperty, StructuredNode, db
 from neomodel._async_compat.util import Util
+from neomodel.config import get_config
 
 
 class User2(StructuredNode):
@@ -50,13 +52,11 @@ def test_cypher():
     assert data[0][0] == "jim1@test.com"
     assert "a.email" in meta
 
-    data, meta = jim.cypher(
-        f"""
+    data, meta = jim.cypher(f"""
             MATCH (a) WHERE {db.get_id_method()}(a)=$self
             MATCH (a)<-[:USER2]-(b)
             RETURN a, b, 3
-        """
-    )
+        """)
     assert "a" in meta and "b" in meta
 
 
@@ -163,3 +163,30 @@ def test_numpy_integration():
     assert isinstance(array, ndarray)
     assert array.shape == (2, 2)
     assert array[0][0] == "jimlu"
+
+
+@mark_sync_test
+def test_cypher_query_transaction_timeout_via_config_fires():
+    config = get_config()
+    original = config.transaction_timeout
+    try:
+        config.transaction_timeout = 1
+        with pytest.raises(
+            ClientError,
+            match="{neo4j_code: Neo.ClientError.Transaction.TransactionTimedOut",
+        ):
+            db.cypher_query("CALL apoc.util.sleep(3000)")
+    finally:
+        config.transaction_timeout = original
+
+
+@mark_sync_test
+def test_cypher_query_transaction_timeout_via_config_succeeds():
+    config = get_config()
+    original = config.transaction_timeout
+    try:
+        config.transaction_timeout = 2
+        results, meta = db.cypher_query("CALL apoc.util.sleep(500)")
+        assert results is not None
+    finally:
+        config.transaction_timeout = original

--- a/test/sync_/test_transactions.py
+++ b/test/sync_/test_transactions.py
@@ -6,6 +6,8 @@ from neo4j.exceptions import ClientError, TransactionError
 from pytest import raises
 
 from neomodel import StringProperty, StructuredNode, UniqueProperty, db
+from neomodel.config import get_config
+from neomodel.sync_.transaction import TransactionProxy
 
 
 class APerson(StructuredNode):
@@ -156,7 +158,10 @@ def test_bookmark_passed_in_to_context(spy_on_db_begin):
     with transaction:
         pass
 
-    assert (spy_on_db_begin)[-1] == ((), {"access_mode": None, "bookmarks": None})
+    assert (spy_on_db_begin)[-1] == (
+        (),
+        {"access_mode": None, "bookmarks": None, "timeout": None},
+    )
     last_bookmarks = transaction.last_bookmarks
 
     transaction.bookmarks = last_bookmarks
@@ -164,7 +169,7 @@ def test_bookmark_passed_in_to_context(spy_on_db_begin):
         pass
     assert spy_on_db_begin[-1] == (
         (),
-        {"access_mode": None, "bookmarks": last_bookmarks},
+        {"access_mode": None, "bookmarks": last_bookmarks, "timeout": None},
     )
 
 
@@ -177,3 +182,54 @@ def test_query_inside_bookmark_transaction():
         assert len([p.name for p in APerson.nodes]) == 2
 
     assert isinstance(transaction.last_bookmarks, Bookmarks)
+
+
+@mark_sync_test
+def test_transaction_timeout_default(spy_on_db_begin):
+    with db.transaction:
+        pass
+
+    assert spy_on_db_begin[-1] == (
+        (),
+        {"access_mode": None, "bookmarks": None, "timeout": None},
+    )
+
+
+@mark_sync_test
+def test_transaction_timeout_explicit(spy_on_db_begin):
+    db.begin(timeout=7.5)
+    db.rollback()
+
+    assert spy_on_db_begin[-1] == ((), {"timeout": 7.5})
+
+
+@mark_sync_test
+def test_transaction_timeout_fires():
+    with raises(
+        ClientError,
+        match="{neo4j_code: Neo.ClientError.Transaction.TransactionTimedOut",
+    ):
+        with TransactionProxy(db, timeout=1):
+            db.cypher_query("CALL apoc.util.sleep(3000)")
+
+
+@mark_sync_test
+def test_transaction_timeout_via_config_fires(spy_on_db_begin):
+    config = get_config()
+    original = config.transaction_timeout
+    try:
+        config.transaction_timeout = 1.42
+        with raises(
+            ClientError,
+            match="{neo4j_code: Neo.ClientError.Transaction.TransactionTimedOut",
+        ):
+            with TransactionProxy(db):
+                db.cypher_query("CALL apoc.util.sleep(3000)")
+    finally:
+        config.transaction_timeout = original
+
+
+@mark_sync_test
+def test_transaction_timeout_succeeds():
+    with TransactionProxy(db, timeout=2):
+        db.cypher_query("CALL apoc.util.sleep(500)")

--- a/test/test_scripts.py
+++ b/test/test_scripts.py
@@ -48,13 +48,20 @@ def test_neomodel_install_labels():
         (element["type"], element["labelsOrTypes"], element["properties"])
         for element in constraints
     ]
-    assert ("UNIQUENESS", ["ScriptsTestNode"], ["personal_id"]) in parsed_constraints
+    # Neo4j renamed constraint types: UNIQUENESS -> NODE_PROPERTY_UNIQUENESS,
+    # RELATIONSHIP_UNIQUENESS -> RELATIONSHIP_PROPERTY_UNIQUENESS
+    assert any(
+        (constraint_type, ["ScriptsTestNode"], ["personal_id"]) in parsed_constraints
+        for constraint_type in ("UNIQUENESS", "NODE_PROPERTY_UNIQUENESS")
+    )
     if db.version_is_higher_than("5.7"):
-        assert (
-            "RELATIONSHIP_UNIQUENESS",
-            ["REL"],
-            ["some_unique_property"],
-        ) in parsed_constraints
+        assert any(
+            (constraint_type, ["REL"], ["some_unique_property"]) in parsed_constraints
+            for constraint_type in (
+                "RELATIONSHIP_UNIQUENESS",
+                "RELATIONSHIP_PROPERTY_UNIQUENESS",
+            )
+        )
     indexes = db.list_indexes()
     parsed_indexes = [
         (element["labelsOrTypes"], element["properties"]) for element in indexes


### PR DESCRIPTION
## Summary

- Add transaction_timeout configuration option (seconds, default None) that sets a server-enforced timeout on all
transactions - both explicit `db.transaction` / `db.begin()` and auto-commit `db.cypher_query()` outside a transaction
- Support per-transaction timeout override via `db.begin(timeout=...)` or `AsyncTransactionProxy(db, timeout=...)`
- Configurable via `get_config().transaction_timeout`, the legacy `config.TRANSACTION_TIMEOUT`,
  or the `NEOMODEL_TRANSACTION_TIMEOUT` environment variable


## Motivation

Neomodel provided no way to limit how long a transaction could run.
The Neo4j driver already supports per-transaction timeouts via
`begin_transaction(timeout=...)` and `Query(text, timeout=...)`,
but neomodel never passed these through.

E.g. in a REST API environment, transaction timeout should be lower than the HTTP gateway timeout,
so clients can always get the result of the operation, and back-end does not get choked with never-ending slow queries.
(Can't just rely on the back-end e.g. FastAPI to detect the client disconnect in time and kill the db transaction).


## Changes

### neomodel/config.py

- New transaction_timeout: `float | None` field with env var `NEOMODEL_TRANSACTION_TIMEOUT`
- Validation (must be positive if set), `from_env` handling for `float | None`, legacy `TRANSACTION_TIMEOUT` property

### neomodel/async_/database.py
(sync code generated via `make-unasync`)

- `begin()` new *timeout* parameter, falls back to `config.transaction_timeout`, forwarded to
  `session.begin_transaction(timeout=...)`
- `cypher_query()` ad-hoc queries wrap the query string in `neo4j.Query(query, timeout=...)` when config timeout is set
- `_run_cypher_query()` type hint to accept `str | Query`

### neomodel/async_/transaction.py
(sync code generated via `make-unasync`)

- `AsyncTransactionProxy.__init__` new *timeout* parameter, forwarded to `db.begin()`


## Tests added

- `test_transaction_timeout_default` verifies timeout=None passed by default
- `test_transaction_timeout_explicit` verifies explicit db.begin(timeout=7.5)
- `test_transaction_timeout_fires` 1s timeout to AsyncTransactionProxy with 3s db sleep raises ClientError
- `test_transaction_timeout_via_config_fires` config-level timeout with 3s db sleep raises ClientError
- `test_transaction_timeout_succeeds` 2s timeout with 0.5s sleep completes normally
- `test_cypher_query_transaction_timeout_via_config_fires`
  cypher_query with 1s config-level timeout with 3s db sleep raises ClientError
- `test_cypher_query_transaction_timeout_via_config_succeeds`
  cypher_query with 2s config timeout and 0.5s db sleep completes normally
